### PR TITLE
Error when build on Windows XP (I386)

### DIFF
--- a/default.build
+++ b/default.build
@@ -7,7 +7,7 @@
 	<property name="tools.folder" value="${root.folder}/tools" />
 	<property name="schema.folder" value="${solution.folder}/schema" />
 	<property name="program.files.x86" value="${environment::get-variable('ProgramFiles(x86)')}" if="${environment::variable-exists('ProgramFiles(x86)')}"/>
-	<property name="program.files.x86" value="${environment::get-variable('ProgramFiles')}" if="${program.files.x86==''}" />
+	<property name="program.files.x86" value="${environment::get-variable('ProgramFiles')}" unless="${property::exists('program.files.x86')}" />
 	<property name="program.files" value="${environment::get-variable('ProgramFiles')}" />
 	<property name="netfx.tools.folder" value="${program.files.x86}/Microsoft SDKs\Windows\v7.0A\Bin\NETFX 4.0 Tools" />
 	<property name="netfx.folder" value="${environment::get-variable('SystemRoot')}/Microsoft.NET" />


### PR DESCRIPTION
I have the following error when I build on Windows XP : 

<pre>
Property evaluation failed.
Expression: ${program.files.x86==''}
              ^^^^^^^^^^^^^^^^^
    Property 'program.files.x86' has not been set.

Total time: 0 seconds.
</pre>

So I made a little change in default.build to get  the proper variable.

Nicolas GRAZIANO nicolas.graziano@gmail.com
