### PR TITLE
Fixed a crash adding COR_PROFILER and COR_ENABLED_PROFILING if they alrea

### DIFF
--- a/main/OpenCover.Console/Program.cs
+++ b/main/OpenCover.Console/Program.cs
@@ -99,12 +99,12 @@ namespace OpenCover.Console
                                                var startInfo =
                                                    new ProcessStartInfo(Path.Combine(Environment.CurrentDirectory,
                                                                                      parser.Target));
-                                               startInfo.EnvironmentVariables.Add("Cor_Profiler",
+                                               startInfo.EnvironmentVariables["Cor_Profiler"] = 
                                                                                   parser.Architecture ==
                                                                                   Architecture.Arch64
                                                                                       ? "{A7A1EDD8-D9A9-4D51-85EA-514A8C4A9100}"
-                                                                                      : "{1542C21D-80C3-45E6-A56C-A9C1E4BEB7B8}");
-                                               startInfo.EnvironmentVariables.Add("Cor_Enable_Profiling", "1");
+                                                                                      : "{1542C21D-80C3-45E6-A56C-A9C1E4BEB7B8}";
+                                               startInfo.EnvironmentVariables["Cor_Enable_Profiling"] = "1";
                                                environment(startInfo.EnvironmentVariables);
 
                                                startInfo.Arguments = parser.TargetArgs;


### PR DESCRIPTION
Fixed a crash adding COR_PROFILER and COR_ENABLED_PROFILING if they already exit.

This is done to allow linking with Typemock Isolator, where the Typemock command line utility (TMockRunner.exe) might already add those environment variables.

I wrote you further details in an email.

(Also, my first ever pull request, so please be gentle :))
