### PR TITLE
Issue #122 Patch

### DIFF
--- a/main/OpenCover.Console/Program.cs
+++ b/main/OpenCover.Console/Program.cs
@@ -327,13 +327,27 @@ namespace OpenCover.Console
                 filter.AddFilter("-[Microsoft.VisualBasic]*");
             }
 
-            if (parser.Filters.Count == 0)
+
+            if (parser.Filters.Count == 0 && string.IsNullOrEmpty(parser.FilterFile))
             {
                 filter.AddFilter("+[*]*");
             }
             else
             {
-                parser.Filters.ForEach(filter.AddFilter);
+                if (!string.IsNullOrEmpty(parser.FilterFile))
+                {
+                    if (!File.Exists(parser.FilterFile))
+                        System.Console.WriteLine("FilterFile '{0}' cannot be found - have you specified your arguments correctly?", parser.FilterFile);
+                    else
+                    {
+                        var filters = File.ReadAllLines(parser.FilterFile);
+                        filters.ToList().ForEach(filter.AddFilter);
+                    }
+                }
+                if (parser.Filters.Count > 0)
+                {
+                    parser.Filters.ForEach(filter.AddFilter);
+                }
             }
 
             filter.AddAttributeExclusionFilters(parser.AttributeExclusionFilters.ToArray());

--- a/main/OpenCover.Framework/CommandLineParser.cs
+++ b/main/OpenCover.Framework/CommandLineParser.cs
@@ -49,6 +49,7 @@ namespace OpenCover.Framework
             builder.AppendLine("    [-register[:user]]");
             builder.AppendLine("    [[\"]-output:<path to file>[\"]]");
             builder.AppendLine("    [[\"]-filter:<space separated filters>[\"]]");
+            builder.AppendLine("    [[\"]-filterfile:<path to file>[\"]]");
             builder.AppendLine("    [-nodefaultfilters]");
             builder.AppendLine("    [-mergebyhash]");
             builder.AppendLine("    [-showunvisited]");
@@ -128,6 +129,9 @@ namespace OpenCover.Framework
                         break;
                     case "filter":
                         Filters = ExtractFilters(GetArgumentValue("filter"));
+                        break;
+                    case "filterfile":
+                        FilterFile = GetArgumentValue("filterfile");
                         break;
                     case "excludebyattribute":
                         AttributeExclusionFilters = GetArgumentValue("excludebyattribute")
@@ -236,6 +240,11 @@ namespace OpenCover.Framework
         /// A list of filters
         /// </summary>
         public List<string> Filters { get; private set; }
+
+        /// <summary>
+        /// A File that has additional filters, one per line.
+        /// </summary>
+        public string FilterFile { get; private set; }
 
         /// <summary>
         /// The offset for the return code - this is to help avoid collisions between opencover return codes and the target


### PR DESCRIPTION
I added a parameter -filterfile. Which takes a text file with one filter
per line to add before the command the filters specified on the command
line

I updated the parser to accept the new argument and also added the filter to the usage output.  I have the filters in the file being added before the ones from the command line (I wasn't sure if order mattered at all but it seemed to make sense to me to do it that way).
