### PR TITLE
Adding Support to Pass arguments as multiple variable

### DIFF
--- a/main/OpenCover.Framework/CommandLineParserBase.cs
+++ b/main/OpenCover.Framework/CommandLineParserBase.cs
@@ -41,7 +41,10 @@ namespace OpenCover.Framework
                 {
                     var arg = trimmed.Substring(0, colonidx);
                     var val = trimmed.Substring(colonidx + 1);
-                    ParsedArguments.Add(arg, val); 
+                    if (!ParsedArguments.ContainsKey(arg))
+                        ParsedArguments.Add(arg, val);
+                    else
+                        ParsedArguments[arg] = ParsedArguments[arg] + " " + val; 
                 }
                 else
                 {


### PR DESCRIPTION
Adding Support to Pass arguments as multiple variable
like passing multiple variable in one command { -targetargs:"/detail:errormessage" -targetargs:"/detail:stdout" }
