### PR TITLE
Populate Tests tab for AppVeyor builds

### DIFF
--- a/build/opencover.build
+++ b/build/opencover.build
@@ -14,6 +14,9 @@
   	
 	<property name="teamcity.dotnet.nunitaddin" value="" unless="${property::exists('teamcity.dotnet.nunitaddin')}" />
 	
+	<property name="nunit-console" value="${nunit.path}/nunit-console.exe" if="${platform=='x64'}" />
+    <property name="nunit-console" value="${nunit.path}/nunit-console-x86.exe" if="${platform=='x86'}" />
+	
     <target name="clean" description="Delete all previously compiled binaries.">
         <delete>
             <fileset>
@@ -99,9 +102,6 @@
     <target name="test" description="Run unit tests" >
         
 		<call target="copy-teamcity-nunit-plugin" unless="${teamcity.dotnet.nunitaddin==''}" />
-		
-        <property name="nunit-console" value="${nunit.path}/nunit-console.exe" if="${platform=='x64'}" />
-        <property name="nunit-console" value="${nunit.path}/nunit-console-x86.exe" if="${platform=='x86'}" />
         
 		<echo message="test: ${solution.folder}/bin/${configuration}/OpenCover.Test.dll" />
 		
@@ -117,9 +117,6 @@
     <target name="test-bdd" description="Run BDD tests" >
         
 		<call target="copy-teamcity-nunit-plugin" unless="${teamcity.dotnet.nunitaddin==''}" />
-		
-        <property name="nunit-console" value="${nunit.path}/nunit-console.exe" if="${platform=='x64'}" />
-        <property name="nunit-console" value="${nunit.path}/nunit-console-x86.exe" if="${platform=='x86'}" />
 
 		<echo message="test-bdd: ${solution.folder}/OpenCover.Specs/bin/${configuration}/OpenCover.Specs.dll" />
         

--- a/build/opencover.build
+++ b/build/opencover.build
@@ -14,8 +14,16 @@
   	
 	<property name="teamcity.dotnet.nunitaddin" value="" unless="${property::exists('teamcity.dotnet.nunitaddin')}" />
 	
-	<property name="nunit-console" value="${nunit.path}/nunit-console.exe" if="${platform=='x64'}" />
-    <property name="nunit-console" value="${nunit.path}/nunit-console-x86.exe" if="${platform=='x86'}" />
+	<choose>
+		<when test="${nunit-in-path}">
+			<property name="nunit-console" value="nunit-console" if="${platform=='x64'}" />
+			<property name="nunit-console" value="nunit-console-x86" if="${platform=='x86'}" />
+		</when>
+		<otherwise>
+			<property name="nunit-console" value="${nunit.path}/nunit-console.exe" if="${platform=='x64'}" />
+			<property name="nunit-console" value="${nunit.path}/nunit-console-x86.exe" if="${platform=='x86'}" />
+		</otherwise>
+	</choose>
 	
     <target name="clean" description="Delete all previously compiled binaries.">
         <delete>


### PR DESCRIPTION
AppVeyor provides a special [NUnit runner](http://www.appveyor.com/docs/running-tests), which publishes test results on the Tests tab of a build real-time.
In order to run this instead of the one in the repo, I've utilized the `nunit-in-path` property in the build, to use NUnit from PATH, if it's present.

With this PR we can have the CI to tell us which test have failed if any (without the need to look at the logs), like in [this case](https://ci.appveyor.com/project/molnargab/opencover/build/1.0.5/tests).