### PR TITLE
fix README: point WiX link to version 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Dropbox is very useful for sharing files [Dropbox](http://db.tt/VanqFDn)
 You will need:
 
 1. Visual Studio VS2013 (Community Edition) or later with C# and C++
-2. WiX 3.9 or later (http://wix.codeplex.com/releases/view/99514)
+2. WiX 3.9 or later (http://wix.codeplex.com/releases/view/136891)
 3. Specflow (http://visualstudiogallery.msdn.microsoft.com/9915524d-7fb0-43c3-bb3c-a8a14fbd40ee)
 
 All other software should be included with this repository. 


### PR DESCRIPTION
link to WiX still points to version 3.7