### PR TITLE
Dispose Resources in ProfilerManager

### DIFF
--- a/main/OpenCover.Framework/Manager/ProfilerManager.cs
+++ b/main/OpenCover.Framework/Manager/ProfilerManager.cs
@@ -159,7 +159,7 @@ namespace OpenCover.Framework.Manager
 
         private void ProcessMessages(WaitHandle[] handles)
         {
-            var threadHandles = new List<Tuple<ManualResetEvent, ManualResetEvent>>();
+            var threadHandles = new List<Tuple<EventWaitHandle, EventWaitHandle>>();
             do
             {
                 switch (WaitHandle.WaitAny(handles))
@@ -191,7 +191,7 @@ namespace OpenCover.Framework.Manager
                     .Select(g => Task.Factory.StartNew(() =>
                     {
                         g.Select(h => h.Item1).ToList().ForEach(h => h.Set());
-                        WaitHandle.WaitAll(g.Select(h => h.Item2).Cast<WaitHandle>().ToArray(), new TimeSpan(0, 0, 20));
+                        WaitHandle.WaitAll(g.Select(h => h.Item2).ToArray(), new TimeSpan(0, 0, 20));
                     })).ToArray();
                 Task.WaitAll(tasks);
             }
@@ -199,7 +199,7 @@ namespace OpenCover.Framework.Manager
             _messageQueue.Enqueue(new byte[0]);
         }
 
-        private Tuple<ManualResetEvent, ManualResetEvent> StartProcessingThread(IManagedCommunicationBlock communicationBlock, IManagedMemoryBlock memoryBlock)
+        private Tuple<EventWaitHandle, EventWaitHandle> StartProcessingThread(IManagedCommunicationBlock communicationBlock, IManagedMemoryBlock memoryBlock)
         {
             var terminateThread = new ManualResetEvent(false);
             var threadTerminated = new ManualResetEvent(false);
@@ -210,7 +210,7 @@ namespace OpenCover.Framework.Manager
                     threadActivated, threadTerminated));
                 threadActivated.WaitOne();
             }
-            return new Tuple<ManualResetEvent, ManualResetEvent>(terminateThread, threadTerminated);
+            return new Tuple<EventWaitHandle, EventWaitHandle>(terminateThread, threadTerminated);
         }
 
         private WaitCallback ProcessBlock(IManagedCommunicationBlock communicationBlock, IManagedMemoryBlock memoryBlock,

--- a/main/OpenCover.Framework/Manager/ProfilerManager.cs
+++ b/main/OpenCover.Framework/Manager/ProfilerManager.cs
@@ -71,7 +71,8 @@ namespace OpenCover.Framework.Manager
             {
                 var handles = new List<WaitHandle> { processMgmt, _mcb.ProfilerRequestsInformation };
 
-                ThreadPool.QueueUserWorkItem(SetProfilerAttributes(process, key, @namespace, environmentKeyRead, processMgmt));
+                ThreadPool.QueueUserWorkItem(
+                    SetProfilerAttributes(process, key, @namespace, environmentKeyRead, processMgmt));
                 ThreadPool.QueueUserWorkItem(SaveVisitData(queueMgmt));
 
                 // wait for the environment key to be read
@@ -83,7 +84,8 @@ namespace OpenCover.Framework.Manager
             }
         }
 
-        private WaitCallback SetProfilerAttributes(Action<Action<StringDictionary>> process, string profilerKey, string profilerNamespace, EventWaitHandle environmentKeyRead, EventWaitHandle processMgmt)
+        private WaitCallback SetProfilerAttributes(Action<Action<StringDictionary>> process, string profilerKey, 
+            string profilerNamespace, EventWaitHandle environmentKeyRead, EventWaitHandle processMgmt)
         {
             return state =>
             {

--- a/main/OpenCover.Framework/Manager/ProfilerManager.cs
+++ b/main/OpenCover.Framework/Manager/ProfilerManager.cs
@@ -194,6 +194,13 @@ namespace OpenCover.Framework.Manager
                         WaitHandle.WaitAll(g.Select(h => h.Item2).ToArray(), new TimeSpan(0, 0, 20));
                     })).ToArray();
                 Task.WaitAll(tasks);
+
+                foreach(var threadHandle in threadHandles)
+                {
+                    threadHandle.Item1.Dispose();
+                    threadHandle.Item2.Dispose();
+                }
+                threadHandles.Clear();
             }
 
             _messageQueue.Enqueue(new byte[0]);


### PR DESCRIPTION
Fixes some dispose issues raised in #242.
Also some of the longer methods were split into smaller ones, this made using blocks available, and hopefully improved readability, in expense of having more parameters on the extracted methods.