### PR TITLE
[WIP] Prerequisites for Mono build

### DIFF
--- a/main/.nuget/NuGet.targets
+++ b/main/.nuget/NuGet.targets
@@ -41,7 +41,7 @@
     
     <PropertyGroup>
         <!-- NuGet command -->
-        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\nuget.exe</NuGetExePath>
+        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\NuGet.exe</NuGetExePath>
         <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
         
         <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>

--- a/main/OpenCover.Console/OpenCover.Console.csproj
+++ b/main/OpenCover.Console/OpenCover.Console.csproj
@@ -139,7 +139,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/main/OpenCover.Extensions/OpenCover.Extensions.csproj
+++ b/main/OpenCover.Extensions/OpenCover.Extensions.csproj
@@ -90,7 +90,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/main/OpenCover.FakesSupport/OpenCover.FakesSupport.csproj
+++ b/main/OpenCover.FakesSupport/OpenCover.FakesSupport.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/main/OpenCover.Framework/OpenCover.Framework.csproj
+++ b/main/OpenCover.Framework/OpenCover.Framework.csproj
@@ -148,7 +148,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <PropertyGroup>
     <PreBuildEvent>
     </PreBuildEvent>

--- a/main/OpenCover.Gendarme.Signer/OpenCover.Gendarme.Signer.csproj
+++ b/main/OpenCover.Gendarme.Signer/OpenCover.Gendarme.Signer.csproj
@@ -14,6 +14,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <ProductVersion>12.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -68,9 +70,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <PostBuildEvent>cd $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)
 $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)\OpenCover.Gendarme.Signer.exe</PostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <PostBuildEvent>mono $(SolutionDir)\OpenCover.Gendarme.Signer\bin\$(ConfigurationName)\OpenCover.Gendarme.Signer.exe</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/main/OpenCover.Gendarme.Signer/OpenCover.Gendarme.Signer.csproj
+++ b/main/OpenCover.Gendarme.Signer/OpenCover.Gendarme.Signer.csproj
@@ -70,12 +70,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <PostBuildEvent>cd $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)
+  <PropertyGroup>
+    <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">cd $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)
 $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)\OpenCover.Gendarme.Signer.exe</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <PostBuildEvent>mono $(SolutionDir)\OpenCover.Gendarme.Signer\bin\$(ConfigurationName)\OpenCover.Gendarme.Signer.exe</PostBuildEvent>
+    <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">mono OpenCover.Gendarme.Signer.exe</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/main/OpenCover.Gendarme.Signer/OpenCover.Gendarme.Signer.csproj
+++ b/main/OpenCover.Gendarme.Signer/OpenCover.Gendarme.Signer.csproj
@@ -67,7 +67,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <PropertyGroup>
     <PostBuildEvent>cd $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)
 $(SolutionDir)OpenCover.Gendarme.Signer\bin\$(ConfigurationName)\OpenCover.Gendarme.Signer.exe</PostBuildEvent>

--- a/main/OpenCover.Gendarme.Signer/Program.cs
+++ b/main/OpenCover.Gendarme.Signer/Program.cs
@@ -11,18 +11,23 @@ namespace OpenCover.Gendarme.Signer
 {
     class Program
     {
-        private const string TargetFolder = @"..\tools\GendarmeSigned";
-        private const string SourceFolder = @"packages\Mono.Gendarme.2.11.0.20121120\tools";
-        private const string StrongNameKey = @"..\build\Version\opencover.gendarme.snk";
+		private const string GendarmeVersion = "2.11.0.20121120";
+
+		private static readonly string GendarmeAssemblyName = string.Format("Mono.Gendarme.{0}", GendarmeVersion);
+
+        private static readonly string TargetFolder = Path.Combine("..", "tools", "GendarmeSigned");
+        private static readonly string SourceFolder = Path.Combine("packages", GendarmeAssemblyName, "tools");
+        private static readonly string StrongNameKey = Path.Combine("..", "build", "Version", "opencover.gendarme.snk");
 
         static void Main(string[] args)
         {
+			var assemblyLocation = Assembly.GetAssembly (typeof(Program)).Location;
+			var assemblyFolder = Path.GetDirectoryName(assemblyLocation);
+            var baseFolder = Path.Combine(assemblyFolder, "..", "..", "..");
 
-
-            var baseFolder = Path.Combine(Assembly.GetAssembly(typeof(Program)).Location, @"..\..\..\..");
-
-            if (!Directory.Exists(Path.Combine(baseFolder, TargetFolder))) 
-                Directory.CreateDirectory(Path.Combine(baseFolder, TargetFolder));
+			var targetDirectory = Path.Combine (baseFolder, TargetFolder);
+            if (!Directory.Exists(targetDirectory)) 
+				Directory.CreateDirectory (targetDirectory);
 
             if (AlreadySigned(baseFolder))
             {
@@ -39,7 +44,7 @@ namespace OpenCover.Gendarme.Signer
 
         private static bool AlreadySigned(string baseFolder)
         {
-            var frameworkAssembly = Path.Combine(baseFolder, TargetFolder + @"\Gendarme.Framework.dll");
+            var frameworkAssembly = Path.Combine(baseFolder, TargetFolder, "Gendarme.Framework.dll");
             if (File.Exists(frameworkAssembly))
             {
                 try
@@ -56,13 +61,13 @@ namespace OpenCover.Gendarme.Signer
 
         private static void SignGendarmeRulesMaintainability(string baseFolder)
         {
-            var frameworkAssembly = Path.Combine(baseFolder, TargetFolder + @"\Gendarme.Framework.dll");
+            var frameworkAssembly = Path.Combine(baseFolder, TargetFolder, "Gendarme.Framework.dll");
             var frameworkDefinition = AssemblyDefinition.ReadAssembly(frameworkAssembly);
             var frameworkAssemblyRef = AssemblyNameReference.Parse(frameworkDefinition.Name.ToString());
 
             var key = Path.Combine(baseFolder, StrongNameKey);
-            var assembly = Path.Combine(baseFolder, SourceFolder + @"\Gendarme.Rules.Maintainability.dll");
-            var newAssembly = Path.Combine(baseFolder, TargetFolder + @"\Gendarme.Rules.Maintainability.dll");
+            var assembly = Path.Combine(baseFolder, SourceFolder, "Gendarme.Rules.Maintainability.dll");
+            var newAssembly = Path.Combine(baseFolder, TargetFolder, "Gendarme.Rules.Maintainability.dll");
 
             assembly = Path.GetFullPath(assembly);
             newAssembly = Path.GetFullPath(newAssembly);
@@ -95,8 +100,8 @@ namespace OpenCover.Gendarme.Signer
         private static void SignGendarmeFramework(string baseFolder)
         {
             var key = Path.Combine(baseFolder, StrongNameKey);
-            var assembly = Path.Combine(baseFolder, SourceFolder + @"\Gendarme.Framework.dll");
-            var newAssembly = Path.Combine(baseFolder, TargetFolder + @"\Gendarme.Framework.dll");
+            var assembly = Path.Combine(baseFolder, SourceFolder, "Gendarme.Framework.dll");
+            var newAssembly = Path.Combine(baseFolder, TargetFolder, "Gendarme.Framework.dll");
 
             assembly = Path.GetFullPath(assembly);
             newAssembly = Path.GetFullPath(newAssembly);

--- a/main/OpenCover.Gendarme.Signer/packages.config
+++ b/main/OpenCover.Gendarme.Signer/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
+  <package id="Mono.Gendarme" version="2.11.0.20121120" targetFramework="net40" />
 </packages>

--- a/main/OpenCover.Integration.Test/OpenCover.Integration.Test.csproj
+++ b/main/OpenCover.Integration.Test/OpenCover.Integration.Test.csproj
@@ -69,7 +69,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/main/OpenCover.Specs/OpenCover.Specs.csproj
+++ b/main/OpenCover.Specs/OpenCover.Specs.csproj
@@ -68,7 +68,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/main/OpenCover.Specs/Steps/PackagingSteps.cs
+++ b/main/OpenCover.Specs/Steps/PackagingSteps.cs
@@ -29,7 +29,7 @@ namespace OpenCover.Specs.Steps
 
         private static dynamic GetTargetPackage(string folder, string ext)
         {
-            var files = Directory.EnumerateFiles(Path.Combine(Environment.CurrentDirectory, @"..\..\..\bin", folder), string.Format("*.{0}", ext));
+            var files = Directory.EnumerateFiles(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "bin", folder), string.Format("*.{0}", ext));
 
             var target = files.Select(f => Regex.Match(f, string.Format(@".*\.(?<version>\d+\.\d+\.\d+)(-rc(?<revision>\d+))?\.{0}", ext)))
                  .Select(m => new { File = m.Value, Version = m.Groups["version"].Value, Revision = m.Groups["revision"].Value })

--- a/main/OpenCover.Test/OpenCover.Test.csproj
+++ b/main/OpenCover.Test/OpenCover.Test.csproj
@@ -282,7 +282,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
#228: This fixes a couple of file reference issues, e.g. upper cased file names or hard-coded path separators.
Though Mono provides a flag to enable backslash as a separator, I think it's more robust to rely on the runtime.

So far the build isn't successful, there seem to be some issue with resolving Gendarme.Rules.Maintanability.dll on Mono 3.12, though I was able to build it with MonoDevelop for Mono 3.2.8 (needed to upgrade to 3.12 in order to fix some failed tests with XmlSerialization).

I think it's safe to merge these changes already, as they're transparent for Windows builds.