### PR TITLE
Fix language statistics on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build/* linguist-vendored
+tools/* linguist-vendored


### PR DESCRIPTION
For some reason linguist considers the HTMLs in the build folder therefore making OpenCover 82% HTML.

```
82.21%  HTML
12.09%  C#
4.76%   C++
0.30%   XSLT
0.18%   Shell
0.15%   CSS
0.11%   C
0.09%   Visual Basic
0.07%   PowerShell
0.03%   Cucumber
0.00%   JavaScript
```

We could ignore this folder using [.gitattributes](https://github.com/github/linguist#using-gitattributes).
Running linguist [locally](https://github.com/github/linguist#usage) with .gitattributes shows somewhat the expected results:

```
69.10%  C#
27.10%  C++
1.70%   XSLT
1.02%   Shell
0.65%   C
0.27%   PowerShell
0.16%   Cucumber
```