### PR TITLE
Add a -version command-line argument

### DIFF
--- a/main/OpenCover.Console/Program.cs
+++ b/main/OpenCover.Console/Program.cs
@@ -502,7 +502,7 @@ namespace OpenCover.Console
                     var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
                     if (entryAssembly == null)
                     {
-                        // logger.Debug("No entry assembly, running from unmanaged application");
+                        Logger.Warn("No entry assembly, running from unmanaged application");
                     }
                     else
                     {

--- a/main/OpenCover.Console/Program.cs
+++ b/main/OpenCover.Console/Program.cs
@@ -489,6 +489,22 @@ namespace OpenCover.Console
                     return false;
                 }
 
+
+                if (parser.PrintVersion)
+                {
+                    var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
+                    if (entryAssembly == null)
+                    {
+                        // logger.Debug("No entry assembly, running from unmanaged application");
+                    }
+                    else
+                    {
+                        var version = entryAssembly.GetName().Version;
+                        System.Console.WriteLine("OpenCover version {0}", version);
+                        return false;
+                    }
+                }
+
                 if (!string.IsNullOrWhiteSpace(parser.TargetDir) && !Directory.Exists(parser.TargetDir))
                 {
                     System.Console.WriteLine("TargetDir '{0}' cannot be found - have you specified your arguments correctly?", parser.TargetDir);

--- a/main/OpenCover.Console/Program.cs
+++ b/main/OpenCover.Console/Program.cs
@@ -43,22 +43,10 @@ namespace OpenCover.Console
 
                 returnCodeOffset = parser.ReturnCodeOffset;
                 var filter = BuildFilter(parser);
+                var perfCounter = CreatePerformanceCounter(parser);
 
                 string outputFile;
                 if (!GetFullOutputFile(parser, out outputFile)) return returnCodeOffset + 1;
-
-                IPerfCounters perfCounter = new NullPerfCounter();
-                if (parser.EnablePerformanceCounters)
-                {
-                    if (new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
-                    {
-                        perfCounter = new PerfCounters();
-                    }
-                    else
-                    {
-                        throw  new InvalidCredentialException("You must be running as an Administrator to enable performance counters.");
-                    }
-                }
 
                 using (var container = new Bootstrapper(logger))
                 {
@@ -457,6 +445,27 @@ namespace OpenCover.Console
 
             return filter;
         }
+
+        private static IPerfCounters CreatePerformanceCounter(CommandLineParser parser)
+        {
+            if (parser.EnablePerformanceCounters)
+            {
+                if (new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
+                {
+                    return new PerfCounters();
+                }
+                else
+                {
+                    throw new InvalidCredentialException(
+                        "You must be running as an Administrator to enable performance counters.");
+                }
+            }
+            else
+            {
+                return new NullPerfCounter();
+            }
+        }
+
 
         private static bool ParseCommandLine(string[] args, out CommandLineParser parser)
         {

--- a/main/OpenCover.Framework/CommandLineParser.cs
+++ b/main/OpenCover.Framework/CommandLineParser.cs
@@ -119,7 +119,7 @@ namespace OpenCover.Framework
             builder.AppendLine("    -?");
             builder.AppendLine("");
             builder.AppendLine("For further information on the command line please visit the wiki");
-            builder.AppendLine("    https://github.com/sawilde/opencover/wiki/Usage");
+            builder.AppendLine("    https://github.com/OpenCover/opencover/wiki/Usage");
             builder.AppendLine("");
             builder.AppendLine("Filters:");
             builder.AppendLine("    Filters are used to include and exclude assemblies and types in the");

--- a/main/OpenCover.Framework/CommandLineParser.cs
+++ b/main/OpenCover.Framework/CommandLineParser.cs
@@ -82,6 +82,7 @@ namespace OpenCover.Framework
             ServiceEnvironment = ServiceEnvironment.None;
             RegExFilters = false;
             Registration = Registration.Normal;
+            PrintVersion = false;
         }
 
         /// <summary>
@@ -117,6 +118,8 @@ namespace OpenCover.Framework
             builder.AppendLine("    [-oldStyle]");
             builder.AppendLine("or");
             builder.AppendLine("    -?");
+            builder.AppendLine("or");
+            builder.AppendLine("    -version");
             builder.AppendLine("");
             builder.AppendLine("For further information on the command line please visit the wiki");
             builder.AppendLine("    https://github.com/OpenCover/opencover/wiki/Usage");
@@ -234,17 +237,15 @@ namespace OpenCover.Framework
                     case "?":
                         PrintUsage = true;
                         break;
+                    case "version":
+                        PrintVersion = true;
+                        break;
                     default:
                         throw new InvalidOperationException(string.Format("The argument {0} is not recognised", key));
                 }
             }
 
-            if (PrintUsage) return;
-
-            if (string.IsNullOrWhiteSpace(Target))
-            {
-                throw new InvalidOperationException("The target argument is required");
-            }
+            ValidateArguments();
         }
 
         private T ExtractValue<T>(string argumentName, Action onError)
@@ -303,6 +304,17 @@ namespace OpenCover.Framework
             }
             return list.Distinct().ToList();
         }
+
+        private void ValidateArguments()
+        {
+            if (PrintUsage || PrintVersion) return;
+
+            if (string.IsNullOrWhiteSpace(Target))
+            {
+                throw new InvalidOperationException("The target argument is required");
+            }
+        }
+
 
         /// <summary>
         /// the switch -register was supplied
@@ -444,6 +456,11 @@ namespace OpenCover.Framework
         /// If an existing output exists then load it and allow merging of test runs
         /// </summary>
         public bool MergeExistingOutputFile { get; private set; }
+
+        /// <summary>
+        /// Instructs the console to print its version and exit
+        /// </summary>
+        public bool PrintVersion { get; private set; }
     }
 
 }

--- a/main/OpenCover.Test/Framework/CommandLineParserTests.cs
+++ b/main/OpenCover.Test/Framework/CommandLineParserTests.cs
@@ -31,7 +31,7 @@ namespace OpenCover.Test.Framework
             Assert.IsFalse(parser.TraceByTest);
             Assert.IsFalse(parser.SkipAutoImplementedProperties);
             Assert.IsFalse(parser.RegExFilters);
-
+            Assert.IsFalse(parser.PrintVersion);
         }
 
         [Test]
@@ -672,6 +672,33 @@ namespace OpenCover.Test.Framework
 
             // assert
             Assert.IsTrue(parser.MergeExistingOutputFile);
+        }
+
+        [Test]
+        public void HandlesVersionArgument()
+        {
+            // arrange
+            var parser = new CommandLineParser(new[] {"-version"});
+
+            // act
+            parser.ExtractAndValidateArguments();
+
+            // assert
+            Assert.IsTrue(parser.PrintVersion);
+        }
+
+        [Test]
+        public void NoArguments_ThrowException()
+        {
+            // arrange
+            var parser = new CommandLineParser(new string[0]);
+            
+            // act
+            var thrownException = Assert.Throws<InvalidOperationException>(parser.ExtractAndValidateArguments);
+
+            // assert
+            Assert.That(thrownException.Message, Contains.Substring("target"));
+            Assert.That(thrownException.Message, Contains.Substring("required"));
         }
     }
 }


### PR DESCRIPTION
I usually use an installed version of OpenCover, though I always have the struggle to decide whether I've already updated it to the latest version or not. I should rather use NuGet perhaps :smiley:.

Anyways, this PR adds a `-version` command to the `CommandLineParser` to print the version of the entry assembly (`OpenCover.Console`) and exit.