### PR TITLE
Access violation is occurred at `AddVisitPointToThreadBuffer`.

### DIFF
--- a/main/OpenCover.Profiler/ProfilerCommunication.cpp
+++ b/main/OpenCover.Profiler/ProfilerCommunication.cpp
@@ -112,7 +112,13 @@ void ProfilerCommunication::ThreadCreated(ThreadID threadID, DWORD osThreadID){
 
 MSG_SendVisitPoints_Request* ProfilerCommunication::GetVisitMapForOSThread(ULONG osThreadID){
     try {
-        return m_visitmap[osThreadID];
+        auto result = m_visitmap.find(osThreadID);
+        if (result != m_visitmap.end())
+            return (*result).second;
+        
+        auto p = new MSG_SendVisitPoints_Request();
+        ::ZeroMemory(p, sizeof(MSG_SendVisitPoints_Request));
+        m_visitmap[osThreadID] = p;
     }
     catch (...){
         auto p = new MSG_SendVisitPoints_Request();


### PR DESCRIPTION
At `AddVisitPointToThreadBuffer`, there is a case that `GetVisitMapForOSThread` returns a null reference.

![default](https://cloud.githubusercontent.com/assets/291065/8908819/25390fae-34b9-11e5-8926-5aadaf800b27.png)

In `GetVisitMapForOSThread`, there is `m_visitmap` which is `std::unordered_map<ULONG, MSG_SendVisitPoints_Request*>`. This type's subscript operator returns [the default value of the data type if the key value is not found](https://msdn.microsoft.com/en-us/library/bb982266.aspx) 

I think you can reproduce this issue by [these sample's steps](https://github.com/urasandesu/Prig.V2Docs/wiki/Profilers-Chain). If using [version 4.5.3723](https://www.nuget.org/packages/OpenCover/4.5.3723), there is no problem. However, if using the latest [version 4.6.166](https://www.nuget.org/packages/OpenCover/4.6.166), you will encounter the access violation like the above image. Therefore, I think you should set new `MSG_SendVisitPoints_Request` to `m_visitmap` even if `osThreadID` is not found :mask: