### PR TITLE
#329 Output all diagnostics to debug output with prefix

### DIFF
--- a/main/OpenCover.Framework/Communication/MessageHandler.cs
+++ b/main/OpenCover.Framework/Communication/MessageHandler.cs
@@ -93,7 +93,7 @@ namespace OpenCover.Framework.Communication
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine("{0}:{1}", ex.GetType(), ex.Message);
+                            DebugOutput.Print(string.Format("{0}:{1}", ex.GetType(), ex.Message));
                             responseGSP.more = false;
                             responseGSP.count = 0;
                             _marshalWrapper.StructureToPtr(responseGSP, pinnedMemory, false);
@@ -141,7 +141,7 @@ namespace OpenCover.Framework.Communication
                         }
                         catch (Exception ex)
                         {
-                            Console.WriteLine("{0}:{1}", ex.GetType(), ex.Message);
+                             DebugOutput.Print(string.Format("{0}:{1}", ex.GetType(), ex.Message));
                             responseGBP.more = false;
                             responseGBP.count = 0;
                             _marshalWrapper.StructureToPtr(responseGBP, pinnedMemory, false);

--- a/main/OpenCover.Framework/DebugOutput.cs
+++ b/main/OpenCover.Framework/DebugOutput.cs
@@ -1,12 +1,15 @@
-﻿using System.Diagnostics;
+﻿using System.Runtime.InteropServices;
 
 namespace OpenCover.Framework
 {
 	internal static class DebugOutput
 	{
+		[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+		private static extern void OutputDebugString(string message);
+
 		public static void Print(string message)
 		{
-			Debug.WriteLine(string.Format("OpenCover: {0}", message));
+			OutputDebugString(string.Format("OpenCover: {0}", message));
 		}
 	}
 }

--- a/main/OpenCover.Framework/DebugOutput.cs
+++ b/main/OpenCover.Framework/DebugOutput.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+
+namespace OpenCover.Framework
+{
+	internal static class DebugOutput
+	{
+		public static void Print(string message)
+		{
+			Debug.WriteLine(string.Format("OpenCover: {0}", message));
+		}
+	}
+}

--- a/main/OpenCover.Framework/Manager/MemoryManager.cs
+++ b/main/OpenCover.Framework/Manager/MemoryManager.cs
@@ -39,7 +39,7 @@ namespace OpenCover.Framework.Manager
             protected string MakeName(string name, int id)
             {
                 var newName = string.Format("{0}{1}{2}{3}", Namespace, name, Key, id);
-                //Console.WriteLine(newName);
+				// DebugOutput.Print(newName);
                 return newName;
             }
         }
@@ -303,7 +303,7 @@ namespace OpenCover.Framework.Manager
 
         public void Dispose()
         {
-            //Console.WriteLine("Disposing...");
+			// DebugOutput.Print("Disposing...");
             lock (_lockObject)
             {
                 foreach(var block in _blocks.Where(b => b.Active))

--- a/main/OpenCover.Framework/OpenCover.Framework.csproj
+++ b/main/OpenCover.Framework/OpenCover.Framework.csproj
@@ -89,6 +89,7 @@
       <Link>Properties\Version.cs</Link>
     </Compile>
     <Compile Include="Bootstrapper.cs" />
+    <Compile Include="DebugOutput.cs" />
     <Compile Include="Filtering\AssemblyAndClassFilter.cs" />
     <Compile Include="Filtering\FilterHelper.cs" />
     <Compile Include="Filtering\FilterType.cs" />

--- a/main/OpenCover.Framework/Symbols/CecilSymbolManager.cs
+++ b/main/OpenCover.Framework/Symbols/CecilSymbolManager.cs
@@ -33,7 +33,7 @@ namespace OpenCover.Framework.Symbols
             }
             catch (Exception)
             {
-                //Console.WriteLine("Exception whilst trying to get the body of method {0}", methodDefinition.FullName);
+				// DebugOutput.Print(string.Format("Exception whilst trying to get the body of method {0}", methodDefinition.FullName));
             }
             return null;
         }
@@ -80,7 +80,7 @@ namespace OpenCover.Framework.Symbols
             if (!string.IsNullOrEmpty(targetfolder) && Directory.Exists(targetfolder))
             {
                 var name = Path.GetFileName(fileName);
-                //Console.WriteLine(targetfolder);
+				// DebugOutput.Print(targetfolder);
                 if (name != null)
                 {
                     if (System.IO.File.Exists(Path.Combine(targetfolder, 

--- a/main/OpenCover.Profiler/ReleaseTrace.h
+++ b/main/OpenCover.Profiler/ReleaseTrace.h
@@ -13,20 +13,25 @@ class CReleaseTrace
 	    {
 	}
 
+	const char* PREFIX = "OpenCover: ";
+	const wchar_t* WPREFIX = L"OpenCover: ";
+
 #pragma warning(push)
 #pragma warning(disable : 4793)
 	void __cdecl operator()(
 		const char *pszFmt, 
 		...) const
-	{
+	{		
 		va_list ptr; va_start(ptr, pszFmt);
         int nBytes = _vscprintf(pszFmt, ptr) + 1;
         va_end(ptr);
-
-        std::vector<char> buffer(nBytes);
+				
+		int prefixLength = strlen(PREFIX);
+		std::vector<char> buffer(nBytes + prefixLength);
+		sprintf_s(&buffer[0], prefixLength + 1, "%s", PREFIX);
 
         va_start(ptr, pszFmt);
-        _vsnprintf_s(&buffer[0], nBytes, nBytes - 1, pszFmt, ptr);
+		_vsnprintf_s(&buffer[prefixLength], nBytes, nBytes - 1, pszFmt, ptr);
         va_end(ptr);
 
         ::OutputDebugStringA(&buffer[0]);
@@ -43,10 +48,12 @@ class CReleaseTrace
         int nBytes = _vscwprintf(pszFmt, ptr) + 1;
         va_end(ptr);
 
-        std::vector<wchar_t> buffer(nBytes);
-
+		int prefixLength = wcslen(WPREFIX);
+		std::vector<wchar_t> buffer(nBytes + prefixLength);
+		swprintf_s(&buffer[0], prefixLength + 1, L"%s", WPREFIX);
+		
         va_start(ptr, pszFmt);
-        _vsnwprintf_s(&buffer[0], nBytes, nBytes - 1, pszFmt, ptr);
+		_vsnwprintf_s(&buffer[prefixLength], nBytes, nBytes - 1, pszFmt, ptr);
         va_end(ptr);
 
         ::OutputDebugStringW(&buffer[0]);


### PR DESCRIPTION
This makes it easier to distinguish OpenCover related messages in debug output. Since OpenCover runs over multiple PIDs I've added a prefix.