### PR TITLE
Spurious BranchPoints

### DIFF
--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -230,6 +230,9 @@ namespace OpenCover.Framework.Persistance
             }
         }
 
+        private static readonly SequencePoint[] emptySeqPoints = new SequencePoint[0];
+        private static readonly BranchPoint[] emptyBranchPoints = new BranchPoint[0];
+
         private void PopulateInstrumentedPoints()
         {
             if (CoverageSession.Modules == null) return;
@@ -245,7 +248,7 @@ namespace OpenCover.Framework.Persistance
             {
                 method.MarkAsSkipped(SkippedMethod.Inferred);
             }
-            
+
             foreach (var module in CoverageSession.Modules.Where(x => !x.ShouldSerializeSkippedDueTo()))
             {
 
@@ -258,9 +261,6 @@ namespace OpenCover.Framework.Persistance
                 }
 
                 #endregion
-
-               	var emptySeqPoints = new SequencePoint[0];
-               	var emptyBranchPoints = new BranchPoint[0];
 
                 foreach (var @class in (module.Classes ?? new Class[0]).Where(x => !x.ShouldSerializeSkippedDueTo()))
                 {

--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -275,12 +275,15 @@ namespace OpenCover.Framework.Persistance
                         	method.BranchPoints = emptyBranchPoints;
                         	branchPoints = emptyBranchPoints;
                         }
-                        
+
                         MapFileReferences(sequencePoints, filesDictionary);
                         MapFileReferences(branchPoints, filesDictionary);
 
                         #region Merge branch-exits
 
+                        sequencePoints = sequencePoints.OrderBy( sp => sp.Offset ).ToArray();
+                        branchPoints = branchPoints.OrderBy( bp => bp.Offset ).ToArray();
+                        
                         // anything to merge?
                         if (sequencePoints.Length != 0 && branchPoints.Length != 0) {
 

--- a/main/OpenCover.Installer/Components.wxs
+++ b/main/OpenCover.Installer/Components.wxs
@@ -16,12 +16,15 @@
       <Component Id="MainProduct" Guid="{D451E3FE-35A6-4946-B0C5-FFE22580891C}">
         <File Id="OPENCOVER_CONSOLE_EXE" Source="..\bin\Release\OpenCover.Console.exe" KeyPath="yes" />
         <File Id="OPENCOVER_CONSOLE_EXE_CONFIG" Source="..\bin\Release\OpenCover.Console.exe.config" />
+        <File Id="OPENCOVER_CONSOLE_PDB" Source="..\bin\Release\OpenCover.Console.pdb" />
       </Component>
       <Component Id="MainFramework" Guid="{6AA473E5-13D3-4963-983E-3F5B007A29D9}">
         <File Id="OPENCOVER_FRAMEWORK_DLL" Source="..\bin\Release\OpenCover.Framework.dll" KeyPath="yes" />
+        <File Id="OPENCOVER_FRAMEWORK_PDB" Source="..\bin\Release\OpenCover.Framework.pdb" />
       </Component>
       <Component Id="Extensions" Guid="{B34740C7-1432-4AD0-A205-A036CBC8EAE4}">
         <File Id="OPENCOVER_EXTENSIONS_DLL" Source="..\bin\Release\OpenCover.Extensions.dll" KeyPath="yes" />
+        <File Id="OPENCOVER_EXTENSIONS_PDB" Source="..\bin\Release\OpenCover.Extensions.pdb" />
       </Component>
       <Component Id="Autofac_3rdParty" Guid="{C0CB1F5D-38BF-4B20-94F4-CD74C349CD79}">
         <File Id="AUTOFAC_DLL" Source="..\bin\Release\Autofac.dll" KeyPath="yes" />
@@ -42,11 +45,6 @@
       <Component Id="Log4Net_3rdParty" Guid="{12E6BB24-EC81-4831-A1CD-9DF0600901A0}">
         <File Id="LOG4NET_DLL" Source="..\bin\Release\log4net.dll" KeyPath="yes" />
         <File Id="LOG4NET_CONFIG" Source="..\bin\Release\log4net.config" />
-      </Component>
-      <Component Id="MainProductSymbols" Guid="6A175C94-446D-49B0-8D29-184F091B5582">
-        <File Id="OPENCOVER_CONSOLE_PDB" Source="..\bin\Release\OpenCover.Console.pdb" KeyPath="yes" />
-        <File Id="OPENCOVER_FRAMEWORK_PDB" Source="..\bin\Release\OpenCover.Framework.pdb" />
-        <File Id="OPENCOVER_EXTENSIONS_PDB" Source="..\bin\Release\OpenCover.Extensions.pdb" />
       </Component>
       <Component Id="SampleCmds" Guid="4D7F8200-EC80-49A2-92FB-2083E8FC469D">
         <File Id="SAMPLE_CMD" Source="Assets\Sample.cmd" Name="Sample.cmd" KeyPath="yes" />
@@ -87,9 +85,7 @@
               </TypeLib>
               -->
         </File>
-      </Component>
-      <Component Id="X86ProfilerSymbols" Guid="E3397930-DC37-46E8-B8D4-9BDC184B8472" >
-        <File Id="OPENCOVER_PROFILER_PDB_X86" Source="..\bin\Release\x86\OpenCover.Profiler.pdb" KeyPath="yes" />
+        <File Id="OPENCOVER_PROFILER_PDB_X86" Source="..\bin\Release\x86\OpenCover.Profiler.pdb" />
       </Component>
     </DirectoryRef>
 
@@ -105,9 +101,7 @@
 				      </TypeLib>
 				      -->
         </File>
-      </Component>
-      <Component Id="X64ProfilerSymbols" Guid="608C08DE-43A9-488D-A5C6-AC9CDF39A7DA" >
-        <File Id="OPENCOVER_PROFILER_PDB_X64" Source="..\bin\Release\x64\OpenCover.Profiler.pdb" KeyPath="yes" />
+        <File Id="OPENCOVER_PROFILER_PDB_X64" Source="..\bin\Release\x64\OpenCover.Profiler.pdb" />
       </Component>
     </DirectoryRef>
 

--- a/main/OpenCover.Installer/Product.wxs
+++ b/main/OpenCover.Installer/Product.wxs
@@ -56,19 +56,12 @@
       <ComponentRef Id="PromptShortcut" />
       <ComponentRef Id="TransformScript" />
       <ComponentRef Id="SimpleTransform" />
+      <ComponentRef Id="Documentation" />
+      <ComponentRef Id="DocumentationShortcut"/>
       <Feature Id="SamplesFeature" Title="Samples" Level="1" Description="Install 32-bit and 64-bit samples. NOTE: Useful for testing the installation.">
         <ComponentRef Id="X86Samples" />
         <ComponentRef Id="X64Samples" />
         <ComponentRef Id="SampleCmds" />
-      </Feature>
-      <Feature Id="DocumentationFeature" Title="Documentation" Level="1" Description="Install the documentation for OpenCover. NOTE: If you are new to OpenCover you may find this information useful.">
-        <ComponentRef Id="Documentation" />
-        <ComponentRef Id="DocumentationShortcut"/>
-      </Feature>
-      <Feature Id="SymbolsFeature" Title="Debug Symbols" Level="100" Description="The Debug Symbols, useful if you are having issues and need to report a bug, with a stack trace, but not necessary for normal operation.">
-        <ComponentRef Id="MainProductSymbols" />
-        <ComponentRef Id="X64ProfilerSymbols" />
-        <ComponentRef Id="X86ProfilerSymbols" />
       </Feature>
     </Feature>
 

--- a/main/OpenCover.Profiler/CodeCoverage.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage.cpp
@@ -25,7 +25,7 @@ HRESULT CCodeCoverage::OpenCoverInitialise(IUnknown *pICorProfilerInfoUnk){
 	ATLTRACE(_T("::OpenCoverInitialise"));
 
     OLECHAR szGuid[40]={0};
-    int nCount = ::StringFromGUID2(CLSID_CodeCoverage, szGuid, 40);
+    ::StringFromGUID2(CLSID_CodeCoverage, szGuid, 40);
     RELTRACE(L"    ::Initialize(...) => CLSID == %s", szGuid);
     //::OutputDebugStringW(szGuid);
 
@@ -351,14 +351,14 @@ void CCodeCoverage::InstrumentMethod(ModuleID moduleId, Method& method,  std::ve
             CoverageInstrumentation::InsertFunctionCall(instructions, pvsig, (FPTR)pt, seqPoints[0].UniqueId);
         if (method.IsInstrumented(0, instructions)) return;
   
-        CoverageInstrumentation::AddBranchCoverage([pvsig, pt](InstructionList& instructions, ULONG uniqueId)->Instruction*
+        CoverageInstrumentation::AddBranchCoverage([pvsig, pt](InstructionList& brinstructions, ULONG uniqueId)->Instruction*
         {
-            return CoverageInstrumentation::InsertFunctionCall(instructions, pvsig, (FPTR)pt, uniqueId);
+            return CoverageInstrumentation::InsertFunctionCall(brinstructions, pvsig, (FPTR)pt, uniqueId);
         }, method, brPoints, seqPoints);
 
-        CoverageInstrumentation::AddSequenceCoverage([pvsig, pt](InstructionList& instructions, ULONG uniqueId)->Instruction*
+        CoverageInstrumentation::AddSequenceCoverage([pvsig, pt](InstructionList& seqinstructions, ULONG uniqueId)->Instruction*
         {
-            return CoverageInstrumentation::InsertFunctionCall(instructions, pvsig, (FPTR)pt, uniqueId);
+            return CoverageInstrumentation::InsertFunctionCall(seqinstructions, pvsig, (FPTR)pt, uniqueId);
         }, method, seqPoints);
     }
     else
@@ -370,14 +370,14 @@ void CCodeCoverage::InstrumentMethod(ModuleID moduleId, Method& method,  std::ve
             CoverageInstrumentation::InsertInjectedMethod(instructions, injectedVisitedMethod, seqPoints[0].UniqueId);
         if (method.IsInstrumented(0, instructions)) return;
   
-        CoverageInstrumentation::AddBranchCoverage([injectedVisitedMethod](InstructionList& instructions, ULONG uniqueId)->Instruction*
+        CoverageInstrumentation::AddBranchCoverage([injectedVisitedMethod](InstructionList& brinstructions, ULONG uniqueId)->Instruction*
         {
-            return CoverageInstrumentation::InsertInjectedMethod(instructions, injectedVisitedMethod, uniqueId);
+            return CoverageInstrumentation::InsertInjectedMethod(brinstructions, injectedVisitedMethod, uniqueId);
         }, method, brPoints, seqPoints);
         
-        CoverageInstrumentation::AddSequenceCoverage([injectedVisitedMethod](InstructionList& instructions, ULONG uniqueId)->Instruction*
+        CoverageInstrumentation::AddSequenceCoverage([injectedVisitedMethod](InstructionList& seqinstructions, ULONG uniqueId)->Instruction*
         {
-            return CoverageInstrumentation::InsertInjectedMethod(instructions, injectedVisitedMethod, uniqueId);
+            return CoverageInstrumentation::InsertInjectedMethod(seqinstructions, injectedVisitedMethod, uniqueId);
         }, method, seqPoints);
     }
 }

--- a/main/OpenCover.Profiler/CodeCoverage.h
+++ b/main/OpenCover.Profiler/CodeCoverage.h
@@ -48,6 +48,10 @@ public:
         m_runtimeType = COR_PRF_DESKTOP_CLR;
         m_useOldStyle = false;
 		m_threshold = 0U;
+        m_tracingEnabled = false;
+        m_cuckooCriticalToken = 0;
+        m_cuckooSafeToken = 0;
+        m_infoHook = nullptr;
     }
 
 DECLARE_REGISTRY_RESOURCEID(IDR_CODECOVERAGE)
@@ -71,11 +75,11 @@ END_COM_MAP()
 
     void FinalRelease()
     {
-        if (m_profilerInfo!=NULL) m_profilerInfo.Release();
-        if (m_profilerInfo2!=NULL) m_profilerInfo2.Release();
-        if (m_profilerInfo3!=NULL) m_profilerInfo3.Release();
+        if (m_profilerInfo != nullptr) m_profilerInfo.Release();
+        if (m_profilerInfo2 != nullptr) m_profilerInfo2.Release();
+        if (m_profilerInfo3 != nullptr) m_profilerInfo3.Release();
 #ifndef _TOOLSETV71
-        if (m_profilerInfo4!=NULL) m_profilerInfo4.Release();
+        if (m_profilerInfo4 != nullptr) m_profilerInfo4.Release();
 #endif
 	}
 
@@ -188,98 +192,98 @@ public:
 
 public:
     virtual HRESULT STDMETHODCALLTYPE Initialize( 
-        /* [in] */ IUnknown *pICorProfilerInfoUnk);
+        /* [in] */ IUnknown *pICorProfilerInfoUnk) override;
         
-    virtual HRESULT STDMETHODCALLTYPE Shutdown( void);
+    virtual HRESULT STDMETHODCALLTYPE Shutdown( void) override;
 
     virtual HRESULT STDMETHODCALLTYPE ModuleAttachedToAssembly( 
         /* [in] */ ModuleID moduleId,
-        /* [in] */ AssemblyID assemblyId);
+        /* [in] */ AssemblyID assemblyId) override;
     
      virtual HRESULT STDMETHODCALLTYPE ModuleLoadFinished( 
         /* [in] */ ModuleID moduleId,
-        /* [in] */ HRESULT hrStatus);
+        /* [in] */ HRESULT hrStatus) override;
 
     virtual HRESULT STDMETHODCALLTYPE JITCompilationStarted( 
         /* [in] */ FunctionID functionId,
-        /* [in] */ BOOL fIsSafeToBlock);
+        /* [in] */ BOOL fIsSafeToBlock) override;
 
 public:
 	// COR_PRF_MONITOR_APPDOMAIN_LOADS
 	virtual HRESULT STDMETHODCALLTYPE AppDomainCreationStarted(
-		/* [in] */ AppDomainID appDomainId)
+		/* [in] */ AppDomainID appDomainId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AppDomainCreationStarted(appDomainId);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE AppDomainCreationFinished(
 		/* [in] */ AppDomainID appDomainId,
-		/* [in] */ HRESULT hrStatus)
+		/* [in] */ HRESULT hrStatus) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AppDomainCreationFinished(appDomainId, hrStatus);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE AppDomainShutdownStarted(
-		/* [in] */ AppDomainID appDomainId)
+		/* [in] */ AppDomainID appDomainId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AppDomainShutdownStarted(appDomainId);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE AppDomainShutdownFinished(
 		/* [in] */ AppDomainID appDomainId,
-		/* [in] */ HRESULT hrStatus)
+		/* [in] */ HRESULT hrStatus) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AppDomainShutdownFinished(appDomainId, hrStatus);
 		return S_OK;
 	}
 
 	// COR_PRF_MONITOR_ASSEMBLY_LOADS
 	virtual HRESULT STDMETHODCALLTYPE AssemblyLoadStarted(
-		/* [in] */ AssemblyID assemblyId)
+		/* [in] */ AssemblyID assemblyId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AssemblyLoadStarted(assemblyId);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE AssemblyLoadFinished(
 		/* [in] */ AssemblyID assemblyId,
-		/* [in] */ HRESULT hrStatus)
+		/* [in] */ HRESULT hrStatus) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AssemblyLoadFinished(assemblyId, hrStatus);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE AssemblyUnloadStarted(
-		/* [in] */ AssemblyID assemblyId)
+		/* [in] */ AssemblyID assemblyId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AssemblyUnloadStarted(assemblyId);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE AssemblyUnloadFinished(
 		/* [in] */ AssemblyID assemblyId,
-		/* [in] */ HRESULT hrStatus)
+		/* [in] */ HRESULT hrStatus) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->AssemblyUnloadFinished(assemblyId, hrStatus);
 		return S_OK;
 	}
 
 	// COR_PRF_MONITOR_MODULE_LOADS
 	virtual HRESULT STDMETHODCALLTYPE ModuleLoadStarted(
-		/* [in] */ ModuleID moduleId)
+		/* [in] */ ModuleID moduleId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->ModuleLoadStarted(moduleId);
 		return S_OK;
 	}
@@ -294,18 +298,18 @@ public:
 	//}
 
 	virtual HRESULT STDMETHODCALLTYPE ModuleUnloadStarted(
-		/* [in] */ ModuleID moduleId)
+		/* [in] */ ModuleID moduleId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->ModuleUnloadStarted(moduleId);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE ModuleUnloadFinished(
 		/* [in] */ ModuleID moduleId,
-		/* [in] */ HRESULT hrStatus)
+		/* [in] */ HRESULT hrStatus) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->ModuleUnloadFinished(moduleId, hrStatus);
 		return S_OK;
 	}
@@ -328,17 +332,17 @@ public:
 	virtual HRESULT STDMETHODCALLTYPE JITCompilationFinished(
 		/* [in] */ FunctionID functionId,
 		/* [in] */ HRESULT hrStatus,
-		/* [in] */ BOOL fIsSafeToBlock)
+		/* [in] */ BOOL fIsSafeToBlock) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->JITCompilationFinished(functionId, hrStatus, fIsSafeToBlock);
 		return S_OK;
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE JITFunctionPitched(
-		/* [in] */ FunctionID functionId)
+		/* [in] */ FunctionID functionId) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->JITFunctionPitched(functionId);
 		return S_OK;
 	}
@@ -346,29 +350,29 @@ public:
 	virtual HRESULT STDMETHODCALLTYPE JITInlining(
 		/* [in] */ FunctionID callerId,
 		/* [in] */ FunctionID calleeId,
-		/* [out] */ BOOL *pfShouldInline)
+		/* [out] */ BOOL *pfShouldInline) override
 	{
-		if (m_chainedProfiler != NULL)
+		if (m_chainedProfiler != nullptr)
 			return m_chainedProfiler->JITInlining(callerId, calleeId, pfShouldInline);
 		return S_OK;
 	}
 
 	// COR_PRF_MONITOR_THREADS
     virtual HRESULT STDMETHODCALLTYPE ThreadCreated(
-        /* [in] */ ThreadID threadId);
+        /* [in] */ ThreadID threadId) override;
 
     virtual HRESULT STDMETHODCALLTYPE ThreadDestroyed(
-        /* [in] */ ThreadID threadId);
+        /* [in] */ ThreadID threadId) override;
 
     virtual HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread(
         /* [in] */ ThreadID managedThreadId,
-        /* [in] */ DWORD osThreadId);
+        /* [in] */ DWORD osThreadId) override;
 
     virtual HRESULT STDMETHODCALLTYPE ThreadNameChanged(
         /* [in] */ ThreadID threadId,
         /* [in] */ ULONG cchName,
         /* [in] */
-        __in_ecount_opt(cchName)  WCHAR name[]);
+        __in_ecount_opt(cchName)  WCHAR name[]) override;
 };
 
 OBJECT_ENTRY_AUTO(__uuidof(CodeCoverage), CCodeCoverage)

--- a/main/OpenCover.Profiler/CodeCoverage_Thread.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage_Thread.cpp
@@ -8,7 +8,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadCreated(
     /* [in] */ ThreadID threadId)
 {
     ATLTRACE(_T("::ThreadCreated(%d)"), threadId);
-    if (m_chainedProfiler != NULL)
+    if (m_chainedProfiler != nullptr)
         m_chainedProfiler->ThreadCreated(threadId);
     return S_OK;
 }
@@ -17,7 +17,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadDestroyed(
     /* [in] */ ThreadID threadId)
 {
     ATLTRACE(_T("::ThreadDestroyed(%d)"), threadId);
-    if (m_chainedProfiler != NULL)
+    if (m_chainedProfiler != nullptr)
         m_chainedProfiler->ThreadDestroyed(threadId);
 
     if (!m_tracingEnabled){
@@ -32,7 +32,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadAssignedToOSThread(
     /* [in] */ DWORD osThreadId)
 {
     ATLTRACE(_T("::ThreadAssignedToOSThread(%d, %d)"), managedThreadId, osThreadId);
-    if (m_chainedProfiler != NULL)
+    if (m_chainedProfiler != nullptr)
         m_chainedProfiler->ThreadAssignedToOSThread(managedThreadId, osThreadId);
 
     if (!m_tracingEnabled){
@@ -49,7 +49,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadNameChanged(
     __in_ecount_opt(cchName)  WCHAR name[])
 {
     ATLTRACE(_T("::ThreadNameChanged(%d, %s)"), threadId, W2T(name));
-    if (m_chainedProfiler != NULL)
+    if (m_chainedProfiler != nullptr)
         m_chainedProfiler->ThreadNameChanged(threadId, cchName, name);
     return S_OK;
 }

--- a/main/OpenCover.Profiler/CoverageInstrumentation.h
+++ b/main/OpenCover.Profiler/CoverageInstrumentation.h
@@ -16,7 +16,7 @@ namespace CoverageInstrumentation
     inline void AddSequenceCoverage(IM instrumentMethod, Method& method, std::vector<SequencePoint> points)
     {
         if (points.size() == 0) return;
-        for (auto it = points.begin(); it != points.end(); it++)
+        for (auto it = points.begin(); it != points.end(); ++it)
         {
             InstructionList instructions;
             instrumentMethod(instructions, (*it).UniqueId);
@@ -59,7 +59,7 @@ namespace CoverageInstrumentation
                     instructions.push_back(pJumpNext);
 
                     // collect branches instrumentation
-                    for(auto sbit = pCurrent->m_branches.begin(); sbit != pCurrent->m_branches.end(); sbit++)
+                    for(auto sbit = pCurrent->m_branches.begin(); sbit != pCurrent->m_branches.end(); ++sbit)
                     {
                         idx++;
                         uniqueId = (*std::find_if(points.begin(), points.end(), [pCurrent, idx](BranchPoint &bp){return bp.Offset == pCurrent->m_origOffset && bp.Path == idx;})).UniqueId;
@@ -89,7 +89,9 @@ namespace CoverageInstrumentation
                     Instruction* pElse = instrumentMethod(instructions, storedId);
                     pJumpNext->m_branches[0] = pElse; // rewire pJumpNext
 
+                    // ReSharper disable once CppPossiblyErroneousEmptyStatements
                     for (it = method.m_instructions.begin(); *it != pNext; ++it);
+
                     method.m_instructions.insert(it, instructions.begin(), instructions.end());
                     
                     // restore 'it' position

--- a/main/OpenCover.Profiler/ExceptionHandler.cpp
+++ b/main/OpenCover.Profiler/ExceptionHandler.cpp
@@ -9,12 +9,13 @@
 
 ExceptionHandler::ExceptionHandler(void)
 {
-    m_tryStart = NULL;
-    m_tryEnd = NULL;
-    m_handlerStart = NULL;
-    m_handlerEnd = NULL;
-    m_filterStart = NULL;
+    m_tryStart = nullptr;
+    m_tryEnd = nullptr;
+    m_handlerStart = nullptr;
+    m_handlerEnd = nullptr;
+    m_filterStart = nullptr;
     m_token = 0;
+    m_handlerType = COR_ILEXCEPTION_CLAUSE_NONE;
 }
 
 

--- a/main/OpenCover.Profiler/Instruction.cpp
+++ b/main/OpenCover.Profiler/Instruction.cpp
@@ -13,6 +13,7 @@ Instruction::Instruction(void)
     m_offset = -1;
     m_isBranch = false;
     m_origOffset = -1;
+    m_jump = nullptr;
 }
 
 Instruction::Instruction(CanonicalName operation, ULONGLONG operand)
@@ -22,6 +23,7 @@ Instruction::Instruction(CanonicalName operation, ULONGLONG operand)
     m_offset = -1;
     m_isBranch = false;
     m_origOffset = -1;
+    m_jump = nullptr;
 }
 
 Instruction::Instruction(CanonicalName operation)
@@ -31,6 +33,7 @@ Instruction::Instruction(CanonicalName operation)
     m_offset = -1;
     m_isBranch = false;
     m_origOffset = -1;
+    m_jump = nullptr;
 }
 
 Instruction::~Instruction(void)

--- a/main/OpenCover.Profiler/ProfileBase.h
+++ b/main/OpenCover.Profiler/ProfileBase.h
@@ -14,303 +14,307 @@ class CProfilerBase : public ICorProfilerCallback3
 #endif
     // ICorProfilerCallback
 public:
+    virtual ~CProfilerBase()
+    {
+    }
+
     virtual HRESULT STDMETHODCALLTYPE Initialize( 
-        /* [in] */ IUnknown *pICorProfilerInfoUnk)
+        /* [in] */ IUnknown *pICorProfilerInfoUnk) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE Shutdown( void)
+    virtual HRESULT STDMETHODCALLTYPE Shutdown( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AppDomainCreationStarted( 
-        /* [in] */ AppDomainID appDomainId)	
+        /* [in] */ AppDomainID appDomainId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AppDomainCreationFinished( 
         /* [in] */ AppDomainID appDomainId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AppDomainShutdownStarted( 
-        /* [in] */ AppDomainID appDomainId)	
+        /* [in] */ AppDomainID appDomainId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AppDomainShutdownFinished( 
         /* [in] */ AppDomainID appDomainId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AssemblyLoadStarted( 
-        /* [in] */ AssemblyID assemblyId) 
+        /* [in] */ AssemblyID assemblyId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AssemblyLoadFinished( 
         /* [in] */ AssemblyID assemblyId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AssemblyUnloadStarted( 
-        /* [in] */ AssemblyID assemblyId) 
+        /* [in] */ AssemblyID assemblyId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE AssemblyUnloadFinished( 
         /* [in] */ AssemblyID assemblyId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ModuleLoadStarted( 
-        /* [in] */ ModuleID moduleId) 
+        /* [in] */ ModuleID moduleId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ModuleLoadFinished( 
         /* [in] */ ModuleID moduleId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ModuleUnloadStarted( 
-        /* [in] */ ModuleID moduleId) 
+        /* [in] */ ModuleID moduleId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ModuleUnloadFinished( 
         /* [in] */ ModuleID moduleId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ModuleAttachedToAssembly( 
         /* [in] */ ModuleID moduleId,
-        /* [in] */ AssemblyID assemblyId)
+        /* [in] */ AssemblyID assemblyId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ClassLoadStarted( 
-        /* [in] */ ClassID classId)	
+        /* [in] */ ClassID classId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ClassLoadFinished( 
         /* [in] */ ClassID classId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ClassUnloadStarted( 
-        /* [in] */ ClassID classId)	
+        /* [in] */ ClassID classId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ClassUnloadFinished( 
         /* [in] */ ClassID classId,
-        /* [in] */ HRESULT hrStatus) 
+        /* [in] */ HRESULT hrStatus) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE FunctionUnloadStarted( 
-        /* [in] */ FunctionID functionId) 
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE JITCompilationStarted( 
         /* [in] */ FunctionID functionId,
-        /* [in] */ BOOL fIsSafeToBlock)
+        /* [in] */ BOOL fIsSafeToBlock) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE JITCompilationFinished( 
         /* [in] */ FunctionID functionId,
         /* [in] */ HRESULT hrStatus,
-        /* [in] */ BOOL fIsSafeToBlock) 
+        /* [in] */ BOOL fIsSafeToBlock) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchStarted( 
         /* [in] */ FunctionID functionId,
-        /* [out] */ BOOL *pbUseCachedFunction)
+        /* [out] */ BOOL *pbUseCachedFunction) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE JITCachedFunctionSearchFinished( 
         /* [in] */ FunctionID functionId,
-        /* [in] */ COR_PRF_JIT_CACHE result)
+        /* [in] */ COR_PRF_JIT_CACHE result) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE JITFunctionPitched( 
-        /* [in] */ FunctionID functionId)
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE JITInlining( 
         /* [in] */ FunctionID callerId,
         /* [in] */ FunctionID calleeId,
-        /* [out] */ BOOL *pfShouldInline)
+        /* [out] */ BOOL *pfShouldInline) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ThreadCreated( 
-        /* [in] */ ThreadID threadId)
+        /* [in] */ ThreadID threadId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ThreadDestroyed( 
-        /* [in] */ ThreadID threadId)
+        /* [in] */ ThreadID threadId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ThreadAssignedToOSThread( 
         /* [in] */ ThreadID managedThreadId,
-        /* [in] */ DWORD osThreadId)
+        /* [in] */ DWORD osThreadId) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RemotingClientInvocationStarted( void)
+    virtual HRESULT STDMETHODCALLTYPE RemotingClientInvocationStarted( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RemotingClientSendingMessage( 
         /* [in] */ GUID *pCookie,
-        /* [in] */ BOOL fIsAsync)
+        /* [in] */ BOOL fIsAsync) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RemotingClientReceivingReply( 
         /* [in] */ GUID *pCookie,
-        /* [in] */ BOOL fIsAsync)
+        /* [in] */ BOOL fIsAsync) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RemotingClientInvocationFinished( void)
+    virtual HRESULT STDMETHODCALLTYPE RemotingClientInvocationFinished( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RemotingServerReceivingMessage( 
         /* [in] */ GUID *pCookie,
-        /* [in] */ BOOL fIsAsync)
+        /* [in] */ BOOL fIsAsync) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RemotingServerInvocationStarted( void)
+    virtual HRESULT STDMETHODCALLTYPE RemotingServerInvocationStarted( void) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RemotingServerInvocationReturned( void)
+    virtual HRESULT STDMETHODCALLTYPE RemotingServerInvocationReturned( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RemotingServerSendingReply( 
         /* [in] */ GUID *pCookie,
-        /* [in] */ BOOL fIsAsync)
+        /* [in] */ BOOL fIsAsync) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE UnmanagedToManagedTransition( 
         /* [in] */ FunctionID functionId,
-        /* [in] */ COR_PRF_TRANSITION_REASON reason )
+        /* [in] */ COR_PRF_TRANSITION_REASON reason ) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ManagedToUnmanagedTransition( 
         /* [in] */ FunctionID functionId,
-        /* [in] */ COR_PRF_TRANSITION_REASON reason)
+        /* [in] */ COR_PRF_TRANSITION_REASON reason) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendStarted( 
-        /* [in] */ COR_PRF_SUSPEND_REASON suspendReason)
+        /* [in] */ COR_PRF_SUSPEND_REASON suspendReason) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendFinished( void)
+    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendFinished( void) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendAborted( void)
+    virtual HRESULT STDMETHODCALLTYPE RuntimeSuspendAborted( void) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RuntimeResumeStarted( void)
+    virtual HRESULT STDMETHODCALLTYPE RuntimeResumeStarted( void) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE RuntimeResumeFinished( void)
+    virtual HRESULT STDMETHODCALLTYPE RuntimeResumeFinished( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RuntimeThreadSuspended( 
-        /* [in] */ ThreadID threadId)
+        /* [in] */ ThreadID threadId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RuntimeThreadResumed( 
-        /* [in] */ ThreadID threadId)
+        /* [in] */ ThreadID threadId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE MovedReferences( 
         /* [in] */ ULONG cMovedObjectIDRanges,
         /* [size_is][in] */ ObjectID oldObjectIDRangeStart[  ],
         /* [size_is][in] */ ObjectID newObjectIDRangeStart[  ],
-        /* [size_is][in] */ ULONG cObjectIDRangeLength[  ])
+        /* [size_is][in] */ ULONG cObjectIDRangeLength[  ]) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ObjectAllocated( 
         /* [in] */ ObjectID objectId,
-        /* [in] */ ClassID classId)
+        /* [in] */ ClassID classId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ObjectsAllocatedByClass( 
         /* [in] */ ULONG cClassCount,
         /* [size_is][in] */ ClassID classIds[  ],
-        /* [size_is][in] */ ULONG cObjects[  ])
+        /* [size_is][in] */ ULONG cObjects[  ]) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ObjectReferences( 
         /* [in] */ ObjectID objectId,
         /* [in] */ ClassID classId,
         /* [in] */ ULONG cObjectRefs,
-        /* [size_is][in] */ ObjectID objectRefIds[  ])
+        /* [size_is][in] */ ObjectID objectRefIds[  ]) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RootReferences( 
         /* [in] */ ULONG cRootRefs,
-        /* [size_is][in] */ ObjectID rootRefIds[  ])
+        /* [size_is][in] */ ObjectID rootRefIds[  ]) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionThrown( 
-        /* [in] */ ObjectID thrownObjectId)
+        /* [in] */ ObjectID thrownObjectId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionEnter( 
-        /* [in] */ FunctionID functionId)
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionLeave( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionLeave( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterEnter( 
-        /* [in] */ FunctionID functionId)
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterLeave( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterLeave( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionSearchCatcherFound( 
-        /* [in] */ FunctionID functionId)
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionOSHandlerEnter( 
-        /* [in] */ UINT_PTR __unused)
+        /* [in] */ UINT_PTR __unused) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionOSHandlerLeave( 
-        /* [in] */ UINT_PTR __unused)
+        /* [in] */ UINT_PTR __unused) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionEnter( 
-        /* [in] */ FunctionID functionId)
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionLeave( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionLeave( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyEnter( 
-        /* [in] */ FunctionID functionId)
+        /* [in] */ FunctionID functionId) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyLeave( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyLeave( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherEnter( 
         /* [in] */ FunctionID functionId,
-        /* [in] */ ObjectID objectId)
+        /* [in] */ ObjectID objectId) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherLeave( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherLeave( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE COMClassicVTableCreated( 
         /* [in] */ ClassID wrappedClassId,
         /* [in] */ REFGUID implementedIID,
         /* [in] */ void *pVTable,
-        /* [in] */ ULONG cSlots)
+        /* [in] */ ULONG cSlots) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE COMClassicVTableDestroyed( 
         /* [in] */ ClassID wrappedClassId,
         /* [in] */ REFGUID implementedIID,
-        /* [in] */ void *pVTable)
+        /* [in] */ void *pVTable) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherFound( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherFound( void) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherExecute( void)
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCLRCatcherExecute( void) override
     { return S_OK; }
 
 // ICorProfilerCallback2
@@ -319,27 +323,27 @@ public:
         /* [in] */ ThreadID threadId,
         /* [in] */ ULONG cchName,
         /* [in] */ 
-        __in_ecount_opt(cchName)  WCHAR name[  ])
+        __in_ecount_opt(cchName)  WCHAR name[  ]) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE GarbageCollectionStarted( 
         /* [in] */ int cGenerations,
         /* [size_is][in] */ BOOL generationCollected[  ],
-        /* [in] */ COR_PRF_GC_REASON reason)
+        /* [in] */ COR_PRF_GC_REASON reason) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE SurvivingReferences( 
         /* [in] */ ULONG cSurvivingObjectIDRanges,
         /* [size_is][in] */ ObjectID objectIDRangeStart[  ],
-        /* [size_is][in] */ ULONG cObjectIDRangeLength[  ])
+        /* [size_is][in] */ ULONG cObjectIDRangeLength[  ]) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE GarbageCollectionFinished( void)
+    virtual HRESULT STDMETHODCALLTYPE GarbageCollectionFinished( void) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE FinalizeableObjectQueued( 
         /* [in] */ DWORD finalizerFlags,
-        /* [in] */ ObjectID objectID)
+        /* [in] */ ObjectID objectID) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE RootReferences2( 
@@ -347,16 +351,16 @@ public:
         /* [size_is][in] */ ObjectID rootRefIds[  ],
         /* [size_is][in] */ COR_PRF_GC_ROOT_KIND rootKinds[  ],
         /* [size_is][in] */ COR_PRF_GC_ROOT_FLAGS rootFlags[  ],
-        /* [size_is][in] */ UINT_PTR rootIds[  ])
+        /* [size_is][in] */ UINT_PTR rootIds[  ]) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE HandleCreated( 
         /* [in] */ GCHandleID handleId,
-        /* [in] */ ObjectID initialObjectId)
+        /* [in] */ ObjectID initialObjectId) override
     { return S_OK; }
         
     virtual HRESULT STDMETHODCALLTYPE HandleDestroyed( 
-        /* [in] */ GCHandleID handleId)
+        /* [in] */ GCHandleID handleId) override
     { return S_OK; }
 
 // ICorProfilerCallback3
@@ -364,13 +368,13 @@ public:
     virtual HRESULT STDMETHODCALLTYPE InitializeForAttach( 
         /* [in] */ IUnknown *pCorProfilerInfoUnk,
         /* [in] */ void *pvClientData,
-        /* [in] */ UINT cbClientData)
+        /* [in] */ UINT cbClientData) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ProfilerAttachComplete( void)
+    virtual HRESULT STDMETHODCALLTYPE ProfilerAttachComplete( void) override
     { return S_OK; }
         
-    virtual HRESULT STDMETHODCALLTYPE ProfilerDetachSucceeded( void)
+    virtual HRESULT STDMETHODCALLTYPE ProfilerDetachSucceeded( void) override
     { return S_OK; }
 
 #ifndef _TOOLSETV71
@@ -379,41 +383,41 @@ public:
     virtual HRESULT STDMETHODCALLTYPE ReJITCompilationStarted( 
         /* [in] */ FunctionID functionId,
         /* [in] */ ReJITID rejitId,
-        /* [in] */ BOOL fIsSafeToBlock)     
-	{ return S_OK; }
+        /* [in] */ BOOL fIsSafeToBlock) override
+    { return S_OK; }
 
     virtual HRESULT STDMETHODCALLTYPE GetReJITParameters( 
         /* [in] */ ModuleID moduleId,
         /* [in] */ mdMethodDef methodId,
-        /* [in] */ ICorProfilerFunctionControl *pFunctionControl)     
-	{ return S_OK; }
+        /* [in] */ ICorProfilerFunctionControl *pFunctionControl) override
+    { return S_OK; }
         
 	virtual HRESULT STDMETHODCALLTYPE ReJITCompilationFinished( 
         /* [in] */ FunctionID functionId,
         /* [in] */ ReJITID rejitId,
         /* [in] */ HRESULT hrStatus,
-        /* [in] */ BOOL fIsSafeToBlock)     
+        /* [in] */ BOOL fIsSafeToBlock) override
 	{ return S_OK; }
         
 	virtual HRESULT STDMETHODCALLTYPE ReJITError( 
         /* [in] */ ModuleID moduleId,
         /* [in] */ mdMethodDef methodId,
         /* [in] */ FunctionID functionId,
-        /* [in] */ HRESULT hrStatus)     
+        /* [in] */ HRESULT hrStatus) override
 	{ return S_OK; }
         
 	virtual HRESULT STDMETHODCALLTYPE MovedReferences2( 
         /* [in] */ ULONG cMovedObjectIDRanges,
         /* [size_is][in] */ ObjectID oldObjectIDRangeStart[  ],
         /* [size_is][in] */ ObjectID newObjectIDRangeStart[  ],
-        /* [size_is][in] */ SIZE_T cObjectIDRangeLength[  ])     
+        /* [size_is][in] */ SIZE_T cObjectIDRangeLength[  ]) override
 	{ return S_OK; }
 
     virtual HRESULT STDMETHODCALLTYPE SurvivingReferences2( 
         /* [in] */ ULONG cSurvivingObjectIDRanges,
         /* [size_is][in] */ ObjectID objectIDRangeStart[  ],
-        /* [size_is][in] */ SIZE_T cObjectIDRangeLength[  ])      
-	{ return S_OK; }
+        /* [size_is][in] */ SIZE_T cObjectIDRangeLength[  ]) override
+    { return S_OK; }
 
 // ICorProfilerCallback5
 public:
@@ -421,7 +425,7 @@ public:
 		/* [in] */ ULONG cRootRefs,
 		/* [size_is][in] */ ObjectID keyRefIds[  ],
 		/* [size_is][in] */ ObjectID valueRefIds[  ],
-		/* [size_is][in] */ GCHandleID rootIds[  ])      
+		/* [size_is][in] */ GCHandleID rootIds[  ]) override
 	{ return S_OK; }
 #endif
 

--- a/main/OpenCover.Profiler/ProfilerCommunication.cpp
+++ b/main/OpenCover.Profiler/ProfilerCommunication.cpp
@@ -20,6 +20,9 @@
 ProfilerCommunication::ProfilerCommunication() 
 {
     m_bufferId = 0;
+    m_pMSG = nullptr;
+    m_pVisitPoints = nullptr;
+    hostCommunicationActive = false;
 }
 
 ProfilerCommunication::~ProfilerCommunication()
@@ -205,10 +208,10 @@ MSG_SendVisitPoints_Request* ProfilerCommunication::AllocateVisitMap(DWORD osThr
 }
 
 MSG_SendVisitPoints_Request* ProfilerCommunication::GetVisitMapForOSThread(ULONG osThreadID){
-    MSG_SendVisitPoints_Request * p = NULL;
+    MSG_SendVisitPoints_Request * p;
     try {
         p = m_visitmap[osThreadID];
-        if (p == NULL)
+        if (p == nullptr)
             p = AllocateVisitMap(osThreadID);
     }
     catch (...){

--- a/main/OpenCover.Profiler/ProfilerCommunication.h
+++ b/main/OpenCover.Profiler/ProfilerCommunication.h
@@ -10,7 +10,6 @@
 #include "Messages.h"
 
 #include <exception>
-#include <concurrent_vector.h>
 
 #include <unordered_map>
 

--- a/main/OpenCover.Profiler/ProfilerInfo.h
+++ b/main/OpenCover.Profiler/ProfilerInfo.h
@@ -22,6 +22,7 @@ class ATL_NO_VTABLE CProfilerInfo :
 public:
 	CProfilerInfo()
 	{
+        m_pProfilerHook = nullptr;
 	}
 
 	BEGIN_COM_MAP(CProfilerInfo)

--- a/main/OpenCover.Profiler/ProfilerInfoBase.h
+++ b/main/OpenCover.Profiler/ProfilerInfoBase.h
@@ -8,7 +8,11 @@ using namespace ATL;
 class CProfilerInfoBase : public ICorProfilerInfo4
 {
 public:
-	void SetProfilerInfo(IUnknown *pICorProfilerInfoUnk){
+    virtual ~CProfilerInfoBase()
+    {
+    }
+
+    void SetProfilerInfo(IUnknown *pICorProfilerInfoUnk){
 		m_pProfilerInfo = pICorProfilerInfoUnk;
 		m_pProfilerInfo2 = pICorProfilerInfoUnk;
 		m_pProfilerInfo3 = pICorProfilerInfoUnk;
@@ -24,7 +28,8 @@ private:
 public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE GetClassFromObject(
 		/* [in] */ ObjectID objectId,
-		/* [out] */ ClassID *pClassId){
+		/* [out] */ ClassID *pClassId) override
+	{
 		//ATLTRACE(_T("GetClassFromObject"));
 		return m_pProfilerInfo->GetClassFromObject(objectId, pClassId);
 	}
@@ -32,7 +37,8 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE GetClassFromToken(
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdTypeDef typeDef,
-		/* [out] */ ClassID *pClassId){
+		/* [out] */ ClassID *pClassId) override
+	{
 		//ATLTRACE(_T("GetClassFromToken"));
 		return m_pProfilerInfo->GetClassFromToken(moduleId, typeDef, pClassId);
 	}
@@ -40,20 +46,23 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE GetCodeInfo(
 		/* [in] */ FunctionID functionId,
 		/* [out] */ LPCBYTE *pStart,
-		/* [out] */ ULONG *pcSize){
+		/* [out] */ ULONG *pcSize) override
+	{
 		//ATLTRACE(_T("GetCodeInfo"));
 		return m_pProfilerInfo->GetCodeInfo(functionId, pStart, pcSize);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetEventMask(
-		/* [out] */ DWORD *pdwEvents){
+		/* [out] */ DWORD *pdwEvents) override
+	{
 		//ATLTRACE(_T("GetEventMask"));
 		return m_pProfilerInfo->GetEventMask(pdwEvents);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetFunctionFromIP(
 		/* [in] */ LPCBYTE ip,
-		/* [out] */ FunctionID *pFunctionId){
+		/* [out] */ FunctionID *pFunctionId) override
+	{
 		//ATLTRACE(_T("GetFunctionFromIP"));
 		return m_pProfilerInfo->GetFunctionFromIP(ip, pFunctionId);
 	}
@@ -61,21 +70,24 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE GetFunctionFromToken(
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdToken token,
-		/* [out] */ FunctionID *pFunctionId){
+		/* [out] */ FunctionID *pFunctionId) override
+	{
 		//ATLTRACE(_T("GetFunctionFromToken"));
 		return m_pProfilerInfo->GetFunctionFromToken(moduleId, token, pFunctionId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetHandleFromThread(
 		/* [in] */ ThreadID threadId,
-		/* [out] */ HANDLE *phThread){
+		/* [out] */ HANDLE *phThread) override
+	{
 		//ATLTRACE(_T("GetHandleFromThread"));
 		return m_pProfilerInfo->GetHandleFromThread(threadId, phThread);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetObjectSize(
 		/* [in] */ ObjectID objectId,
-		/* [out] */ ULONG *pcSize){
+		/* [out] */ ULONG *pcSize) override
+	{
 		//ATLTRACE(_T("GetObjectSize"));
 		return m_pProfilerInfo->GetObjectSize(objectId, pcSize);
 	}
@@ -84,20 +96,23 @@ public: // ICorProfilerInfo
 		/* [in] */ ClassID classId,
 		/* [out] */ CorElementType *pBaseElemType,
 		/* [out] */ ClassID *pBaseClassId,
-		/* [out] */ ULONG *pcRank){
+		/* [out] */ ULONG *pcRank) override
+	{
 		//ATLTRACE(_T("IsArrayClass"));
 		return m_pProfilerInfo->IsArrayClass(classId, pBaseElemType, pBaseClassId, pcRank);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetThreadInfo(
 		/* [in] */ ThreadID threadId,
-		/* [out] */ DWORD *pdwWin32ThreadId){
+		/* [out] */ DWORD *pdwWin32ThreadId) override
+	{
 		//ATLTRACE(_T("GetThreadInfo"));
 		return m_pProfilerInfo->GetThreadInfo(threadId, pdwWin32ThreadId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetCurrentThreadID(
-		/* [out] */ ThreadID *pThreadId){
+		/* [out] */ ThreadID *pThreadId) override
+	{
 		//ATLTRACE(_T("GetCurrentThreadID"));
 		return m_pProfilerInfo->GetCurrentThreadID(pThreadId);
 	}
@@ -105,7 +120,8 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE GetClassIDInfo(
 		/* [in] */ ClassID classId,
 		/* [out] */ ModuleID *pModuleId,
-		/* [out] */ mdTypeDef *pTypeDefToken){
+		/* [out] */ mdTypeDef *pTypeDefToken) override
+	{
 		//ATLTRACE(_T("GetClassIDInfo"));
 		return m_pProfilerInfo->GetClassIDInfo(classId, pModuleId, pTypeDefToken);
 	}
@@ -114,13 +130,15 @@ public: // ICorProfilerInfo
 		/* [in] */ FunctionID functionId,
 		/* [out] */ ClassID *pClassId,
 		/* [out] */ ModuleID *pModuleId,
-		/* [out] */ mdToken *pToken){
+		/* [out] */ mdToken *pToken) override
+	{
 		//ATLTRACE(_T("GetFunctionInfo"));
 		return m_pProfilerInfo->GetFunctionInfo(functionId, pClassId, pModuleId, pToken);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetEventMask(
-		/* [in] */ DWORD dwEvents){
+		/* [in] */ DWORD dwEvents) override
+	{
 		ATLTRACE(_T("CProfilerInfoBase::SetEventMask(0x%X)"), dwEvents);
 		return m_pProfilerInfo->SetEventMask(dwEvents);
 	}
@@ -128,13 +146,15 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE SetEnterLeaveFunctionHooks(
 		/* [in] */ FunctionEnter *pFuncEnter,
 		/* [in] */ FunctionLeave *pFuncLeave,
-		/* [in] */ FunctionTailcall *pFuncTailcall){
+		/* [in] */ FunctionTailcall *pFuncTailcall) override
+	{
 		//ATLTRACE(_T("SetEnterLeaveFunctionHooks"));
 		return m_pProfilerInfo->SetEnterLeaveFunctionHooks(pFuncEnter, pFuncLeave, pFuncTailcall);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetFunctionIDMapper(
-		/* [in] */ FunctionIDMapper *pFunc){
+		/* [in] */ FunctionIDMapper *pFunc) override
+	{
 		//ATLTRACE(_T("SetFunctionIDMapper"));
 		return m_pProfilerInfo->SetFunctionIDMapper(pFunc);
 	}
@@ -143,7 +163,8 @@ public: // ICorProfilerInfo
 		/* [in] */ FunctionID functionId,
 		/* [in] */ REFIID riid,
 		/* [out] */ IUnknown **ppImport,
-		/* [out] */ mdToken *pToken){
+		/* [out] */ mdToken *pToken) override
+	{
 		//ATLTRACE(_T("GetTokenAndMetaDataFromFunction"));
 		return m_pProfilerInfo->GetTokenAndMetaDataFromFunction(functionId, riid, ppImport, pToken);
 	}
@@ -155,7 +176,8 @@ public: // ICorProfilerInfo
 		/* [out] */ ULONG *pcchName,
 		/* [annotation][out] */
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
-		/* [out] */ AssemblyID *pAssemblyId){
+		/* [out] */ AssemblyID *pAssemblyId) override
+	{
 		//ATLTRACE(_T("GetModuleInfo"));
 		return m_pProfilerInfo->GetModuleInfo(moduleId, ppBaseLoadAddress, cchName, pcchName, szName, pAssemblyId);
 	}
@@ -164,7 +186,8 @@ public: // ICorProfilerInfo
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ DWORD dwOpenFlags,
 		/* [in] */ REFIID riid,
-		/* [out] */ IUnknown **ppOut){
+		/* [out] */ IUnknown **ppOut) override
+	{
 		//ATLTRACE(_T("GetModuleMetaData"));
 		return m_pProfilerInfo->GetModuleMetaData(moduleId, dwOpenFlags, riid, ppOut);
 	}
@@ -173,14 +196,16 @@ public: // ICorProfilerInfo
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdMethodDef methodId,
 		/* [out] */ LPCBYTE *ppMethodHeader,
-		/* [out] */ ULONG *pcbMethodSize){
+		/* [out] */ ULONG *pcbMethodSize) override
+	{
 		//ATLTRACE(_T("GetILFunctionBody"));
 		return m_pProfilerInfo->GetILFunctionBody(moduleId, methodId, ppMethodHeader, pcbMethodSize);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetILFunctionBodyAllocator(
 		/* [in] */ ModuleID moduleId,
-		/* [out] */ IMethodMalloc **ppMalloc){
+		/* [out] */ IMethodMalloc **ppMalloc) override
+	{
 		//ATLTRACE(_T("GetILFunctionBodyAllocator"));
 		return m_pProfilerInfo->GetILFunctionBodyAllocator(moduleId, ppMalloc);
 	}
@@ -188,7 +213,8 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE SetILFunctionBody(
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdMethodDef methodid,
-		/* [in] */ LPCBYTE pbNewILMethodHeader){
+		/* [in] */ LPCBYTE pbNewILMethodHeader) override
+	{
 		//ATLTRACE(_T("SetILFunctionBody"));
 		return m_pProfilerInfo->SetILFunctionBody(moduleId, methodid, pbNewILMethodHeader);
 	}
@@ -199,7 +225,8 @@ public: // ICorProfilerInfo
 		/* [out] */ ULONG *pcchName,
 		/* [annotation][out] */
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
-		/* [out] */ ProcessID *pProcessId){
+		/* [out] */ ProcessID *pProcessId) override
+	{
 		//ATLTRACE(_T("GetAppDomainInfo"));
 		return m_pProfilerInfo->GetAppDomainInfo(appDomainId, cchName, pcchName, szName, pProcessId);
 	}
@@ -211,18 +238,21 @@ public: // ICorProfilerInfo
 		/* [annotation][out] */
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
 		/* [out] */ AppDomainID *pAppDomainId,
-		/* [out] */ ModuleID *pModuleId){
+		/* [out] */ ModuleID *pModuleId) override
+	{
 		//ATLTRACE(_T("GetAssemblyInfo"));
 		return m_pProfilerInfo->GetAssemblyInfo(assemblyId, cchName, pcchName, szName, pAppDomainId, pModuleId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetFunctionReJIT(
-		/* [in] */ FunctionID functionId){
+		/* [in] */ FunctionID functionId) override
+	{
 		//ATLTRACE(_T("SetFunctionReJIT"));
 		return m_pProfilerInfo->SetFunctionReJIT(functionId);
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE ForceGC(void){
+	virtual HRESULT STDMETHODCALLTYPE ForceGC(void) override
+	{
 		//ATLTRACE(_T("GetClassFromObject"));
 		return m_pProfilerInfo->ForceGC();
 	}
@@ -231,39 +261,45 @@ public: // ICorProfilerInfo
 		/* [in] */ FunctionID functionId,
 		/* [in] */ BOOL fStartJit,
 		/* [in] */ ULONG cILMapEntries,
-		/* [size_is][in] */ COR_IL_MAP rgILMapEntries[]){
+		/* [size_is][in] */ COR_IL_MAP rgILMapEntries[]) override
+	{
 		//ATLTRACE(_T("SetILInstrumentedCodeMap"));
 		return m_pProfilerInfo->SetILInstrumentedCodeMap(functionId, fStartJit, cILMapEntries, rgILMapEntries);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetInprocInspectionInterface(
-		/* [out] */ IUnknown **ppicd){
+		/* [out] */ IUnknown **ppicd) override
+	{
 		//ATLTRACE(_T("GetInprocInspectionInterface"));
 		return m_pProfilerInfo->GetInprocInspectionInterface(ppicd);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetInprocInspectionIThisThread(
-		/* [out] */ IUnknown **ppicd){
+		/* [out] */ IUnknown **ppicd) override
+	{
 		//ATLTRACE(_T("GetInprocInspectionIThisThread"));
 		return m_pProfilerInfo->GetInprocInspectionIThisThread(ppicd);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetThreadContext(
 		/* [in] */ ThreadID threadId,
-		/* [out] */ ContextID *pContextId){
+		/* [out] */ ContextID *pContextId) override
+	{
 		//ATLTRACE(_T("GetThreadContext"));
 		return m_pProfilerInfo->GetThreadContext(threadId, pContextId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE BeginInprocDebugging(
 		/* [in] */ BOOL fThisThreadOnly,
-		/* [out] */ DWORD *pdwProfilerContext){
+		/* [out] */ DWORD *pdwProfilerContext) override
+	{
 		//ATLTRACE(_T("BeginInprocDebugging"));
 		return m_pProfilerInfo->BeginInprocDebugging(fThisThreadOnly, pdwProfilerContext);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EndInprocDebugging(
-		/* [in] */ DWORD dwProfilerContext){
+		/* [in] */ DWORD dwProfilerContext) override
+	{
 		//ATLTRACE(_T("EndInprocDebugging"));
 		return m_pProfilerInfo->EndInprocDebugging(dwProfilerContext);
 	}
@@ -272,7 +308,8 @@ public: // ICorProfilerInfo
 		/* [in] */ FunctionID functionId,
 		/* [in] */ ULONG32 cMap,
 		/* [out] */ ULONG32 *pcMap,
-		/* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[]){
+		/* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[]) override
+	{
 		//ATLTRACE(_T("GetILToNativeMapping"));
 		return m_pProfilerInfo->GetILToNativeMapping(functionId, cMap, pcMap, map);
 	}
@@ -284,7 +321,8 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 infoFlags,
 		/* [in] */ void *clientData,
 		/* [size_is][in] */ BYTE context[],
-		/* [in] */ ULONG32 contextSize){
+		/* [in] */ ULONG32 contextSize) override
+	{
 		//ATLTRACE(_T("DoStackSnapshot"));
 		return m_pProfilerInfo2->DoStackSnapshot(thread, callback, infoFlags, clientData, context, contextSize);
 	}
@@ -292,7 +330,8 @@ public: //ICorProfilerInfo2
 	virtual HRESULT STDMETHODCALLTYPE SetEnterLeaveFunctionHooks2(
 		/* [in] */ FunctionEnter2 *pFuncEnter,
 		/* [in] */ FunctionLeave2 *pFuncLeave,
-		/* [in] */ FunctionTailcall2 *pFuncTailcall){
+		/* [in] */ FunctionTailcall2 *pFuncTailcall) override
+	{
 		//ATLTRACE(_T("SetEnterLeaveFunctionHooks2"));
 		return m_pProfilerInfo2->SetEnterLeaveFunctionHooks2(pFuncEnter, pFuncLeave, pFuncTailcall);
 	}
@@ -305,7 +344,8 @@ public: //ICorProfilerInfo2
 		/* [out] */ mdToken *pToken,
 		/* [in] */ ULONG32 cTypeArgs,
 		/* [out] */ ULONG32 *pcTypeArgs,
-		/* [out] */ ClassID typeArgs[]){
+		/* [out] */ ClassID typeArgs[]) override
+	{
 		//ATLTRACE(_T("GetFunctionInfo2"));
 		return m_pProfilerInfo2->GetFunctionInfo2(funcId, frameInfo, pClassId, pModuleId, pToken, cTypeArgs, pcTypeArgs, typeArgs);
 	}
@@ -313,7 +353,8 @@ public: //ICorProfilerInfo2
 	virtual HRESULT STDMETHODCALLTYPE GetStringLayout(
 		/* [out] */ ULONG *pBufferLengthOffset,
 		/* [out] */ ULONG *pStringLengthOffset,
-		/* [out] */ ULONG *pBufferOffset){
+		/* [out] */ ULONG *pBufferOffset) override
+	{
 		//ATLTRACE(_T("GetStringLayout"));
 		return m_pProfilerInfo2->GetStringLayout(pBufferLengthOffset, pStringLengthOffset, pBufferOffset);
 	}
@@ -323,7 +364,8 @@ public: //ICorProfilerInfo2
 		/* [out][in] */ COR_FIELD_OFFSET rFieldOffset[],
 		/* [in] */ ULONG cFieldOffset,
 		/* [out] */ ULONG *pcFieldOffset,
-		/* [out] */ ULONG *pulClassSize){
+		/* [out] */ ULONG *pulClassSize) override
+	{
 		//ATLTRACE(_T("GetClassLayout"));
 		return m_pProfilerInfo2->GetClassLayout(classID, rFieldOffset, cFieldOffset, pcFieldOffset, pulClassSize);
 	}
@@ -335,7 +377,8 @@ public: //ICorProfilerInfo2
 		/* [out] */ ClassID *pParentClassId,
 		/* [in] */ ULONG32 cNumTypeArgs,
 		/* [out] */ ULONG32 *pcNumTypeArgs,
-		/* [out] */ ClassID typeArgs[]){
+		/* [out] */ ClassID typeArgs[]) override
+	{
 		//ATLTRACE(_T("GetClassIDInfo2"));
 		return m_pProfilerInfo2->GetClassIDInfo2(classId, pModuleId, pTypeDefToken, pParentClassId, cNumTypeArgs, pcNumTypeArgs, typeArgs);
 	}
@@ -344,7 +387,8 @@ public: //ICorProfilerInfo2
 		/* [in] */ FunctionID functionID,
 		/* [in] */ ULONG32 cCodeInfos,
 		/* [out] */ ULONG32 *pcCodeInfos,
-		/* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[]){
+		/* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[]) override
+	{
 		//ATLTRACE(_T("GetCodeInfo2"));
 		return m_pProfilerInfo2->GetCodeInfo2(functionID, cCodeInfos, pcCodeInfos, codeInfos);
 	}
@@ -354,7 +398,8 @@ public: //ICorProfilerInfo2
 		/* [in] */ mdTypeDef typeDef,
 		/* [in] */ ULONG32 cTypeArgs,
 		/* [size_is][in] */ ClassID typeArgs[],
-		/* [out] */ ClassID *pClassID){
+		/* [out] */ ClassID *pClassID) override
+	{
 		//ATLTRACE(_T("GetClassFromTokenAndTypeArgs"));
 		return m_pProfilerInfo2->GetClassFromTokenAndTypeArgs(moduleID, typeDef, cTypeArgs, typeArgs, pClassID);
 	}
@@ -365,14 +410,16 @@ public: //ICorProfilerInfo2
 		/* [in] */ ClassID classId,
 		/* [in] */ ULONG32 cTypeArgs,
 		/* [size_is][in] */ ClassID typeArgs[],
-		/* [out] */ FunctionID *pFunctionID){
+		/* [out] */ FunctionID *pFunctionID) override
+	{
 		//ATLTRACE(_T("GetFunctionFromTokenAndTypeArgs"));
 		return m_pProfilerInfo2->GetFunctionFromTokenAndTypeArgs(moduleID, funcDef, classId, cTypeArgs, typeArgs, pFunctionID);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EnumModuleFrozenObjects(
 		/* [in] */ ModuleID moduleID,
-		/* [out] */ ICorProfilerObjectEnum **ppEnum){
+		/* [out] */ ICorProfilerObjectEnum **ppEnum) override
+	{
 		//ATLTRACE(_T("GetClassFromObject"));
 		return m_pProfilerInfo2->EnumModuleFrozenObjects(moduleID, ppEnum);
 	}
@@ -382,21 +429,24 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 cDimensions,
 		/* [size_is][out] */ ULONG32 pDimensionSizes[],
 		/* [size_is][out] */ int pDimensionLowerBounds[],
-		/* [out] */ BYTE **ppData){
+		/* [out] */ BYTE **ppData) override
+	{
 		//ATLTRACE(_T("GetArrayObjectInfo"));
 		return m_pProfilerInfo2->GetArrayObjectInfo(objectId, cDimensions, pDimensionSizes, pDimensionLowerBounds, ppData);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetBoxClassLayout(
 		/* [in] */ ClassID classId,
-		/* [out] */ ULONG32 *pBufferOffset){
+		/* [out] */ ULONG32 *pBufferOffset) override
+	{
 		//ATLTRACE(_T("GetBoxClassLayout"));
 		return m_pProfilerInfo2->GetBoxClassLayout(classId, pBufferOffset);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetThreadAppDomain(
 		/* [in] */ ThreadID threadId,
-		/* [out] */ AppDomainID *pAppDomainId){
+		/* [out] */ AppDomainID *pAppDomainId) override
+	{
 		//ATLTRACE(_T("GetThreadAppDomain"));
 		return m_pProfilerInfo2->GetThreadAppDomain(threadId, pAppDomainId);
 	}
@@ -404,7 +454,8 @@ public: //ICorProfilerInfo2
 	virtual HRESULT STDMETHODCALLTYPE GetRVAStaticAddress(
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
-		/* [out] */ void **ppAddress){
+		/* [out] */ void **ppAddress) override
+	{
 		//ATLTRACE(_T("GetRVAStaticAddress"));
 		return m_pProfilerInfo2->GetRVAStaticAddress(classId, fieldToken, ppAddress);
 	}
@@ -413,7 +464,8 @@ public: //ICorProfilerInfo2
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ AppDomainID appDomainId,
-		/* [out] */ void **ppAddress){
+		/* [out] */ void **ppAddress) override
+	{
 		//ATLTRACE(_T("GetAppDomainStaticAddress"));
 		return m_pProfilerInfo2->GetAppDomainStaticAddress(classId, fieldToken, appDomainId, ppAddress);
 	}
@@ -422,7 +474,8 @@ public: //ICorProfilerInfo2
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ ThreadID threadId,
-		/* [out] */ void **ppAddress){
+		/* [out] */ void **ppAddress) override
+	{
 		//ATLTRACE(_T("GetThreadStaticAddress"));
 		return m_pProfilerInfo2->GetThreadStaticAddress(classId, fieldToken, threadId, ppAddress);
 	}
@@ -431,7 +484,8 @@ public: //ICorProfilerInfo2
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ ContextID contextId,
-		/* [out] */ void **ppAddress){
+		/* [out] */ void **ppAddress) override
+	{
 		//ATLTRACE(_T("GetContextStaticAddress"));
 		return m_pProfilerInfo2->GetContextStaticAddress(classId, fieldToken, contextId, ppAddress);
 	}
@@ -439,7 +493,8 @@ public: //ICorProfilerInfo2
 	virtual HRESULT STDMETHODCALLTYPE GetStaticFieldInfo(
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
-		/* [out] */ COR_PRF_STATIC_TYPE *pFieldInfo){
+		/* [out] */ COR_PRF_STATIC_TYPE *pFieldInfo) override
+	{
 		//ATLTRACE(_T("GetStaticFieldInfo"));
 		return m_pProfilerInfo2->GetStaticFieldInfo(classId, fieldToken, pFieldInfo);
 	}
@@ -447,47 +502,54 @@ public: //ICorProfilerInfo2
 	virtual HRESULT STDMETHODCALLTYPE GetGenerationBounds(
 		/* [in] */ ULONG cObjectRanges,
 		/* [out] */ ULONG *pcObjectRanges,
-		/* [length_is][size_is][out] */ COR_PRF_GC_GENERATION_RANGE ranges[]){
+		/* [length_is][size_is][out] */ COR_PRF_GC_GENERATION_RANGE ranges[]) override
+	{
 		//ATLTRACE(_T("GetGenerationBounds"));
 		return m_pProfilerInfo2->GetGenerationBounds(cObjectRanges, pcObjectRanges, ranges);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetObjectGeneration(
 		/* [in] */ ObjectID objectId,
-		/* [out] */ COR_PRF_GC_GENERATION_RANGE *range){
+		/* [out] */ COR_PRF_GC_GENERATION_RANGE *range) override
+	{
 		//ATLTRACE(_T("GetObjectGeneration"));
 		return m_pProfilerInfo2->GetObjectGeneration(objectId, range);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetNotifiedExceptionClauseInfo(
-		/* [out] */ COR_PRF_EX_CLAUSE_INFO *pinfo){
+		/* [out] */ COR_PRF_EX_CLAUSE_INFO *pinfo) override
+	{
 		//ATLTRACE(_T("GetNotifiedExceptionClauseInfo"));
 		return m_pProfilerInfo2->GetNotifiedExceptionClauseInfo(pinfo);
 	}
 
 public: // ICorProfilerInfo3
 	virtual HRESULT STDMETHODCALLTYPE EnumJITedFunctions(
-		/* [out] */ ICorProfilerFunctionEnum **ppEnum){
+		/* [out] */ ICorProfilerFunctionEnum **ppEnum) override
+	{
 		//ATLTRACE(_T("EnumJITedFunctions"));
 		return m_pProfilerInfo3->EnumJITedFunctions(ppEnum);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE RequestProfilerDetach(
-		/* [in] */ DWORD dwExpectedCompletionMilliseconds){
+		/* [in] */ DWORD dwExpectedCompletionMilliseconds) override
+	{
 		//ATLTRACE(_T("RequestProfilerDetach"));
 		return m_pProfilerInfo3->RequestProfilerDetach(dwExpectedCompletionMilliseconds);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetFunctionIDMapper2(
 		/* [in] */ FunctionIDMapper2 *pFunc,
-		/* [in] */ void *clientData){
+		/* [in] */ void *clientData) override
+	{
 		//ATLTRACE(_T("SetFunctionIDMapper2"));
 		return m_pProfilerInfo3->SetFunctionIDMapper2(pFunc, clientData);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetStringLayout2(
 		/* [out] */ ULONG *pStringLengthOffset,
-		/* [out] */ ULONG *pBufferOffset){
+		/* [out] */ ULONG *pBufferOffset) override
+	{
 		//ATLTRACE(_T("GetStringLayout2"));
 		return m_pProfilerInfo3->GetStringLayout2(pStringLengthOffset, pBufferOffset);
 	}
@@ -495,7 +557,8 @@ public: // ICorProfilerInfo3
 	virtual HRESULT STDMETHODCALLTYPE SetEnterLeaveFunctionHooks3(
 		/* [in] */ FunctionEnter3 *pFuncEnter3,
 		/* [in] */ FunctionLeave3 *pFuncLeave3,
-		/* [in] */ FunctionTailcall3 *pFuncTailcall3){
+		/* [in] */ FunctionTailcall3 *pFuncTailcall3) override
+	{
 		//ATLTRACE(_T("SetEnterLeaveFunctionHooks3"));
 		return m_pProfilerInfo3->SetEnterLeaveFunctionHooks3(pFuncEnter3, pFuncLeave3, pFuncTailcall3);
 	}
@@ -503,7 +566,8 @@ public: // ICorProfilerInfo3
 	virtual HRESULT STDMETHODCALLTYPE SetEnterLeaveFunctionHooks3WithInfo(
 		/* [in] */ FunctionEnter3WithInfo *pFuncEnter3WithInfo,
 		/* [in] */ FunctionLeave3WithInfo *pFuncLeave3WithInfo,
-		/* [in] */ FunctionTailcall3WithInfo *pFuncTailcall3WithInfo){
+		/* [in] */ FunctionTailcall3WithInfo *pFuncTailcall3WithInfo) override
+	{
 		//ATLTRACE(_T("SetEnterLeaveFunctionHooks3WithInfo"));
 		return m_pProfilerInfo3->SetEnterLeaveFunctionHooks3WithInfo(pFuncEnter3WithInfo, pFuncLeave3WithInfo, pFuncTailcall3WithInfo);
 	}
@@ -513,7 +577,8 @@ public: // ICorProfilerInfo3
 		/* [in] */ COR_PRF_ELT_INFO eltInfo,
 		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo,
 		/* [out][in] */ ULONG *pcbArgumentInfo,
-		/* [size_is][out] */ COR_PRF_FUNCTION_ARGUMENT_INFO *pArgumentInfo){
+		/* [size_is][out] */ COR_PRF_FUNCTION_ARGUMENT_INFO *pArgumentInfo) override
+	{
 		//ATLTRACE(_T("GetFunctionEnter3Info"));
 		return m_pProfilerInfo3->GetFunctionEnter3Info(functionId, eltInfo, pFrameInfo, pcbArgumentInfo, pArgumentInfo);
 	}
@@ -522,7 +587,8 @@ public: // ICorProfilerInfo3
 		/* [in] */ FunctionID functionId,
 		/* [in] */ COR_PRF_ELT_INFO eltInfo,
 		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo,
-		/* [out] */ COR_PRF_FUNCTION_ARGUMENT_RANGE *pRetvalRange){
+		/* [out] */ COR_PRF_FUNCTION_ARGUMENT_RANGE *pRetvalRange) override
+	{
 		//ATLTRACE(_T("GetFunctionLeave3Info"));
 		return m_pProfilerInfo3->GetFunctionLeave3Info(functionId, eltInfo, pFrameInfo, pRetvalRange);
 	}
@@ -530,13 +596,15 @@ public: // ICorProfilerInfo3
 	virtual HRESULT STDMETHODCALLTYPE GetFunctionTailcall3Info(
 		/* [in] */ FunctionID functionId,
 		/* [in] */ COR_PRF_ELT_INFO eltInfo,
-		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo){
+		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo) override
+	{
 		//ATLTRACE(_T("GetFunctionTailcall3Info"));
 		return m_pProfilerInfo3->GetFunctionTailcall3Info(functionId, eltInfo, pFrameInfo);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EnumModules(
-		/* [out] */ ICorProfilerModuleEnum **ppEnum){
+		/* [out] */ ICorProfilerModuleEnum **ppEnum) override
+	{
 		//ATLTRACE(_T("EnumModules"));
 		return m_pProfilerInfo3->EnumModules(ppEnum);
 	}
@@ -551,7 +619,8 @@ public: // ICorProfilerInfo3
 		/* [in] */ ULONG cchVersionString,
 		/* [out] */ ULONG *pcchVersionString,
 		/* [annotation][out] */
-		_Out_writes_to_(cchVersionString, *pcchVersionString)  WCHAR szVersionString[]){
+		_Out_writes_to_(cchVersionString, *pcchVersionString)  WCHAR szVersionString[]) override
+	{
 		//ATLTRACE(_T("GetRuntimeInformation"));
 		return m_pProfilerInfo3->GetRuntimeInformation(pClrInstanceId, pRuntimeType, pMajorVersion,
 			pMinorVersion, pBuildNumber, pQFEVersion, cchVersionString, pcchVersionString, szVersionString);
@@ -562,7 +631,8 @@ public: // ICorProfilerInfo3
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ AppDomainID appDomainId,
 		/* [in] */ ThreadID threadId,
-		/* [out] */ void **ppAddress){
+		/* [out] */ void **ppAddress) override
+	{
 		//ATLTRACE(_T("GetThreadStaticAddress2"));
 		return m_pProfilerInfo3->GetThreadStaticAddress2(classId,
 			fieldToken, appDomainId, threadId, ppAddress);
@@ -572,7 +642,8 @@ public: // ICorProfilerInfo3
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ ULONG32 cAppDomainIds,
 		/* [out] */ ULONG32 *pcAppDomainIds,
-		/* [length_is][size_is][out] */ AppDomainID appDomainIds[]){
+		/* [length_is][size_is][out] */ AppDomainID appDomainIds[]) override
+	{
 		//ATLTRACE(_T("GetAppDomainsContainingModule"));
 		return m_pProfilerInfo3->GetAppDomainsContainingModule(moduleId,
 			cAppDomainIds, pcAppDomainIds, appDomainIds);
@@ -586,7 +657,8 @@ public: // ICorProfilerInfo3
 		/* [annotation][out] */
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
 		/* [out] */ AssemblyID *pAssemblyId,
-		/* [out] */ DWORD *pdwModuleFlags){
+		/* [out] */ DWORD *pdwModuleFlags) override
+	{
 		//ATLTRACE(_T("GetModuleInfo2"));
 		return m_pProfilerInfo3->GetModuleInfo2(moduleId, ppBaseLoadAddress, cchName,
 			pcchName, szName, pAssemblyId, pdwModuleFlags);
@@ -594,12 +666,14 @@ public: // ICorProfilerInfo3
 
 public: // ICorProfilerInfo4
 	virtual HRESULT STDMETHODCALLTYPE EnumThreads(
-		/* [out] */ ICorProfilerThreadEnum **ppEnum){
+		/* [out] */ ICorProfilerThreadEnum **ppEnum) override
+	{
 		//ATLTRACE(_T("EnumThreads"));
 		return m_pProfilerInfo4->EnumThreads(ppEnum);
 	}
 
-	virtual HRESULT STDMETHODCALLTYPE InitializeCurrentThread(void){
+	virtual HRESULT STDMETHODCALLTYPE InitializeCurrentThread(void) override
+	{
 		//ATLTRACE(_T("InitializeCurrentThread"));
 		return m_pProfilerInfo4->InitializeCurrentThread();
 	}
@@ -607,7 +681,8 @@ public: // ICorProfilerInfo4
 	virtual HRESULT STDMETHODCALLTYPE RequestReJIT(
 		/* [in] */ ULONG cFunctions,
 		/* [size_is][in] */ ModuleID moduleIds[],
-		/* [size_is][in] */ mdMethodDef methodIds[]){
+		/* [size_is][in] */ mdMethodDef methodIds[]) override
+	{
 		//ATLTRACE(_T("RequestReJIT"));
 		return m_pProfilerInfo4->RequestReJIT(cFunctions, moduleIds, methodIds);
 	}
@@ -616,7 +691,8 @@ public: // ICorProfilerInfo4
 		/* [in] */ ULONG cFunctions,
 		/* [size_is][in] */ ModuleID moduleIds[],
 		/* [size_is][in] */ mdMethodDef methodIds[],
-		/* [size_is][out] */ HRESULT status[]){
+		/* [size_is][out] */ HRESULT status[]) override
+	{
 		//ATLTRACE(_T("RequestRevert"));
 		return m_pProfilerInfo4->RequestRevert(cFunctions, moduleIds, methodIds, status);
 	}
@@ -626,7 +702,8 @@ public: // ICorProfilerInfo4
 		/* [in] */ ReJITID reJitId,
 		/* [in] */ ULONG32 cCodeInfos,
 		/* [out] */ ULONG32 *pcCodeInfos,
-		/* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[]){
+		/* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[]) override
+	{
 		//ATLTRACE(_T("GetCodeInfo3"));
 		return m_pProfilerInfo4->GetCodeInfo3(functionID, reJitId, cCodeInfos, pcCodeInfos, codeInfos);
 	}
@@ -634,7 +711,8 @@ public: // ICorProfilerInfo4
 	virtual HRESULT STDMETHODCALLTYPE GetFunctionFromIP2(
 		/* [in] */ LPCBYTE ip,
 		/* [out] */ FunctionID *pFunctionId,
-		/* [out] */ ReJITID *pReJitId){
+		/* [out] */ ReJITID *pReJitId) override
+	{
 		//ATLTRACE(_T("GetFunctionFromIP2"));
 		return m_pProfilerInfo4->GetFunctionFromIP2(ip, pFunctionId, pReJitId);
 	}
@@ -643,7 +721,8 @@ public: // ICorProfilerInfo4
 		/* [in] */ FunctionID functionId,
 		/* [in] */ ULONG cReJitIds,
 		/* [out] */ ULONG *pcReJitIds,
-		/* [length_is][size_is][out] */ ReJITID reJitIds[]){
+		/* [length_is][size_is][out] */ ReJITID reJitIds[]) override
+	{
 		//ATLTRACE(_T("GetClassFromObject"));
 		return m_pProfilerInfo4->GetReJITIDs(functionId, cReJitIds, pcReJitIds, reJitIds);
 	}
@@ -653,20 +732,23 @@ public: // ICorProfilerInfo4
 		/* [in] */ ReJITID reJitId,
 		/* [in] */ ULONG32 cMap,
 		/* [out] */ ULONG32 *pcMap,
-		/* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[]){
+		/* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[]) override
+	{
 		//ATLTRACE(_T("GetILToNativeMapping2"));
 		return m_pProfilerInfo4->GetILToNativeMapping2(functionId, reJitId, cMap, pcMap, map);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EnumJITedFunctions2(
-		/* [out] */ ICorProfilerFunctionEnum **ppEnum){
+		/* [out] */ ICorProfilerFunctionEnum **ppEnum) override
+	{
 		//ATLTRACE(_T("EnumJITedFunctions2"));
 		return m_pProfilerInfo4->EnumJITedFunctions2(ppEnum);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetObjectSize2(
 		/* [in] */ ObjectID objectId,
-		/* [out] */ SIZE_T *pcSize){
+		/* [out] */ SIZE_T *pcSize) override
+	{
 		//ATLTRACE(_T("GetObjectSize2"));
 		return m_pProfilerInfo4->GetObjectSize2(objectId, pcSize);
 	}

--- a/main/OpenCover.Profiler/SharedMemory.cpp
+++ b/main/OpenCover.Profiler/SharedMemory.cpp
@@ -12,13 +12,13 @@ CSharedMemory::~CSharedMemory() {
 }
 
 void CSharedMemory::CloseMapping() {
-    if (m_hMemory != NULL) {
-        for (auto it = m_viewMap.begin(); it != m_viewMap.end(); it++) {
+    if (m_hMemory != nullptr) {
+        for (auto it = m_viewMap.begin(); it != m_viewMap.end(); ++it) {
             ::UnmapViewOfFile((*it).first);
         }
         m_viewMap.clear();
         CloseHandle(m_hMemory);
-        m_hMemory = NULL;
+        m_hMemory = nullptr;
     }
 }
 
@@ -29,7 +29,7 @@ void CSharedMemory::OpenFileMapping(const TCHAR* pName) {
 
 void* CSharedMemory::MapViewOfFile(DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, SIZE_T dwNumberOfBytesToMap) {
     if (!IsValid()) {
-        return NULL;
+        return nullptr;
     }
     void* pMappedData = ::MapViewOfFile(
         m_hMemory,
@@ -39,14 +39,14 @@ void* CSharedMemory::MapViewOfFile(DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow
         dwNumberOfBytesToMap
         ); 
 
-     if (pMappedData != NULL) {
+     if (pMappedData != nullptr) {
          m_viewMap.push_back(std::pair<void*, SIZE_T>(pMappedData, dwNumberOfBytesToMap));
      }
      return pMappedData;
 }
 
 void CSharedMemory::FlushViewOfFile() {
-    for (auto it = m_viewMap.begin(); it != m_viewMap.end(); it++) {
+    for (auto it = m_viewMap.begin(); it != m_viewMap.end(); ++it) {
         ::FlushViewOfFile((*it).first, (*it).second);
     }
 }

--- a/main/OpenCover.Profiler/SharedMemory.h
+++ b/main/OpenCover.Profiler/SharedMemory.h
@@ -8,14 +8,14 @@
 class CSharedMemory
 {
 public:
-    CSharedMemory() : m_hMemory(NULL) { }
+    CSharedMemory() : m_hMemory(nullptr) { }
     ~CSharedMemory();
 
 public:
     void OpenFileMapping(const TCHAR *pName);  
     void* MapViewOfFile(DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, SIZE_T dwNumberOfBytesToMap);
     static DWORD GetAllocationGranularity();
-    bool IsValid() {return m_hMemory!=NULL; }
+    bool IsValid() { return m_hMemory != nullptr; }
     void FlushViewOfFile();
 
 private:

--- a/main/OpenCover.Profiler/Synchronization.h
+++ b/main/OpenCover.Profiler/Synchronization.h
@@ -10,38 +10,38 @@
 class CMutex
 {
 public:
-    CMutex() : m_hMutex(NULL) {}
+    CMutex() : m_hMutex(nullptr) {}
     ~CMutex() { CloseHandle(); }
-    bool IsValid() {return m_hMutex!=NULL; }
+    bool IsValid() { return m_hMutex != nullptr; }
 
 public:
-    void Initialise(const TCHAR * pName) { CloseHandle(); m_hMutex = ::CreateMutex(NULL, false, pName); }
-    void Enter(){ if (m_hMutex!=NULL) { ::WaitForSingleObject(m_hMutex, INFINITE);} }
-    void Leave(){ if (m_hMutex!=NULL) { ::ReleaseMutex(m_hMutex);} }
+    void Initialise(const TCHAR * pName) { CloseHandle(); m_hMutex = ::CreateMutex(nullptr, false, pName); }
+    void Enter(){ if (m_hMutex != nullptr) { ::WaitForSingleObject(m_hMutex, INFINITE); } }
+    void Leave(){ if (m_hMutex != nullptr) { ::ReleaseMutex(m_hMutex); } }
 
 private:
     HANDLE m_hMutex;
-	void CloseHandle() {if (m_hMutex!=NULL) { ::CloseHandle(m_hMutex); m_hMutex=NULL; }}
+    void CloseHandle() { if (m_hMutex != nullptr) { ::CloseHandle(m_hMutex); m_hMutex = nullptr; } }
 };
 
 class CSemaphore
 {
 public:
-    CSemaphore() : m_hSemaphore(NULL) {}
+    CSemaphore() : m_hSemaphore(nullptr) {}
     ~CSemaphore() { CloseHandle(); }
-    bool IsValid() { return m_hSemaphore != NULL; }
+    bool IsValid() { return m_hSemaphore != nullptr; }
 
 public:
-    void Initialise(const TCHAR * pName) { CloseHandle(); m_hSemaphore = ::CreateSemaphore(NULL, 0, 2, pName); _handleName = pName; }
+    void Initialise(const TCHAR * pName) { CloseHandle(); m_hSemaphore = ::CreateSemaphore(nullptr, 0, 2, pName); _handleName = pName; }
     void Enter(){ if (IsValid()) { ::WaitForSingleObject(m_hSemaphore, INFINITE); } }
-    void Leave(){ if (IsValid()) { ::ReleaseSemaphore(m_hSemaphore, 1, NULL); } }
+    void Leave(){ if (IsValid()) { ::ReleaseSemaphore(m_hSemaphore, 1, nullptr); } }
 
 protected:
     HANDLE m_hSemaphore;
     tstring _handleName;
 
 private:
-    void CloseHandle() { if (IsValid()) { ::CloseHandle(m_hSemaphore); m_hSemaphore = NULL; } }
+    void CloseHandle() { if (IsValid()) { ::CloseHandle(m_hSemaphore); m_hSemaphore = nullptr; } }
 };
 
 class CSemaphoreEx : public CSemaphore {
@@ -78,12 +78,12 @@ private:
 class CEvent
 {
 public:
-    CEvent () : m_hEvent(NULL) { }
+    CEvent() : m_hEvent(nullptr) { }
     ~CEvent() { CloseHandle(); }
-    bool IsValid() {return m_hEvent!=NULL; }
+    bool IsValid() { return m_hEvent != nullptr; }
 
 public:
-    void Initialise(const TCHAR * pName, BOOL bManualReset = TRUE) { CloseHandle(); m_hEvent = ::CreateEvent(NULL, bManualReset, FALSE, pName); }
+    void Initialise(const TCHAR * pName, BOOL bManualReset = TRUE) { CloseHandle(); m_hEvent = ::CreateEvent(nullptr, bManualReset, FALSE, pName); }
     void Set() { ::SetEvent(m_hEvent); }
     void Wait() { ::WaitForSingleObject(m_hEvent, INFINITE); }
 
@@ -92,6 +92,6 @@ public:
 
 private:
     HANDLE m_hEvent;
-	void CloseHandle() {if (m_hEvent!= NULL) { ::CloseHandle(m_hEvent); m_hEvent = NULL; }}
+    void CloseHandle() { if (m_hEvent != nullptr) { ::CloseHandle(m_hEvent); m_hEvent = nullptr; } }
 };
 

--- a/main/OpenCover.Specs/Steps/PackagingSteps.cs
+++ b/main/OpenCover.Specs/Steps/PackagingSteps.cs
@@ -160,7 +160,7 @@ namespace OpenCover.Specs.Steps
                 Path.GetDirectoryName(output), Path.GetFileNameWithoutExtension(output), "x86", Path.GetExtension(output));
 
             var outputXml64 = string.Format(@"{0}\{1}_{2}.{3}",
-                Path.GetDirectoryName(output), Path.GetFileNameWithoutExtension(output), "x86", Path.GetExtension(output));
+                Path.GetDirectoryName(output), Path.GetFileNameWithoutExtension(output), "x64", Path.GetExtension(output));
 
             Assert.IsTrue(File.Exists(outputXml86));
             Assert.IsTrue(File.Exists(outputXml64));

--- a/main/OpenCover.Test/Framework/Persistance/BasePersistenceTests.cs
+++ b/main/OpenCover.Test/Framework/Persistance/BasePersistenceTests.cs
@@ -340,8 +340,8 @@ namespace OpenCover.Test.Framework.Persistance
 
             Assert.AreEqual(0, Instance.CoverageSession.Modules[0].Classes[0].Methods[0].Summary.NumSequencePoints);
             Assert.AreEqual(0, Instance.CoverageSession.Modules[0].Classes[0].Methods[0].Summary.VisitedSequencePoints);
-            Assert.AreEqual(1, Instance.CoverageSession.Modules[0].Classes[0].Methods[0].Summary.NumBranchPoints);
-            Assert.AreEqual(1, Instance.CoverageSession.Modules[0].Classes[0].Methods[0].Summary.VisitedBranchPoints);
+            Assert.AreEqual(0, Instance.CoverageSession.Modules[0].Classes[0].Methods[0].Summary.NumBranchPoints);
+            Assert.AreEqual(0, Instance.CoverageSession.Modules[0].Classes[0].Methods[0].Summary.VisitedBranchPoints);
         }
 
         [Test]


### PR DESCRIPTION
This modification should exclude from reports all "spurious" branch-points as part of existing branch-points processing (loop). Also fixes so far uncovered case when BP offset is lower than first SP start-offset.

I think that IL profiler must be high-language-instruction and compiler-construction unaware&neutral, and profile every IL instruction it is supposed to profile.

Problem with matching BP to SP is that SP has start-line, start-column, end-line, end-column, but only start-offset, no end-offset. BP has only offset info. Compiler can insert arbitrary IL code in space between two SP's.
