### PR TITLE
Fix incorrect concurrent use of collections

### DIFF
--- a/main/OpenCover.Framework/Model/InstrumentationPoint.cs
+++ b/main/OpenCover.Framework/Model/InstrumentationPoint.cs
@@ -13,6 +13,7 @@ namespace OpenCover.Framework.Model
     public class InstrumentationPoint
     {
         private static int _instrumentPoint;
+        private static object _addInstrumentPointSync = new object();
         private static readonly List<InstrumentationPoint> InstrumentPoints;
 
         static InstrumentationPoint()
@@ -114,10 +115,13 @@ namespace OpenCover.Framework.Model
         /// </summary>
         public InstrumentationPoint()
         {
-            UniqueSequencePoint = (uint)Interlocked.Increment(ref _instrumentPoint);
-            InstrumentPoints.Add(this);
-            OrigSequencePoint = UniqueSequencePoint;
-        } 
+            lock (_addInstrumentPointSync)
+            {
+                UniqueSequencePoint = (uint)++_instrumentPoint;
+                InstrumentPoints.Add(this);
+                OrigSequencePoint = UniqueSequencePoint;
+            }
+        }
 
         /// <summary>
         /// Store the number of visits

--- a/main/OpenCover.Profiler/CodeCoverage.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage.cpp
@@ -22,7 +22,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::Initialize(
 }
 
 HRESULT CCodeCoverage::OpenCoverInitialise(IUnknown *pICorProfilerInfoUnk){
-	ATLTRACE(_T("::OpenCoverInitialise"));
+	ATLTRACE(_T("::OpenCoverInitialise\n"));
 
     OLECHAR szGuid[40]={0};
     int nCount = ::StringFromGUID2(CLSID_CodeCoverage, szGuid, 40);
@@ -39,13 +39,13 @@ HRESULT CCodeCoverage::OpenCoverInitialise(IUnknown *pICorProfilerInfoUnk){
     //::OutputDebugStringW(szModuleName);
 
     if (g_pProfiler!=NULL) 
-        RELTRACE(_T("Another instance of the profiler is running under this process..."));
+        RELTRACE(_T("Another instance of the profiler is running under this process...\n"));
 
     m_profilerInfo = pICorProfilerInfoUnk;
-    if (m_profilerInfo != NULL) ATLTRACE(_T("    ::Initialize (m_profilerInfo OK)"));
+    if (m_profilerInfo != NULL) ATLTRACE(_T("    ::Initialize (m_profilerInfo OK)\n"));
     if (m_profilerInfo == NULL) return E_FAIL;
     m_profilerInfo2 = pICorProfilerInfoUnk;
-    if (m_profilerInfo2 != NULL) ATLTRACE(_T("    ::Initialize (m_profilerInfo2 OK)"));
+    if (m_profilerInfo2 != NULL) ATLTRACE(_T("    ::Initialize (m_profilerInfo2 OK)\n"));
     if (m_profilerInfo2 == NULL) return E_FAIL;
     m_profilerInfo3 = pICorProfilerInfoUnk;
 #ifndef _TOOLSETV71
@@ -55,7 +55,7 @@ HRESULT CCodeCoverage::OpenCoverInitialise(IUnknown *pICorProfilerInfoUnk){
     ZeroMemory(&m_runtimeVersion, sizeof(m_runtimeVersion));
     if (m_profilerInfo3 != NULL) 
     {
-        ATLTRACE(_T("    ::Initialize (m_profilerInfo3 OK)"));
+        ATLTRACE(_T("    ::Initialize (m_profilerInfo3 OK)\n"));
         
         ZeroMemory(&m_runtimeVersion, sizeof(m_runtimeVersion));
         m_profilerInfo3->GetRuntimeInformation(NULL, &m_runtimeType, 
@@ -64,37 +64,37 @@ HRESULT CCodeCoverage::OpenCoverInitialise(IUnknown *pICorProfilerInfoUnk){
             &m_runtimeVersion.usBuildNumber, 
             &m_runtimeVersion.usRevisionNumber, 0, NULL, NULL); 
 
-        ATLTRACE(_T("    ::Initialize (Runtime %d)"), m_runtimeType);
+        ATLTRACE(_T("    ::Initialize (Runtime %d)\n"), m_runtimeType);
     }
 
     TCHAR key[1024] = {0};
     ::GetEnvironmentVariable(_T("OpenCover_Profiler_Key"), key, 1024);
-    RELTRACE(_T("    ::Initialize(...) => key = %s"), key);
+    RELTRACE(_T("    ::Initialize(...) => key = %s\n"), key);
 
     TCHAR ns[1024] = {0};
     ::GetEnvironmentVariable(_T("OpenCover_Profiler_Namespace"), ns, 1024);
-    ATLTRACE(_T("    ::Initialize(...) => ns = %s"), ns);
+    ATLTRACE(_T("    ::Initialize(...) => ns = %s\n"), ns);
 
     TCHAR instrumentation[1024] = {0};
     ::GetEnvironmentVariable(_T("OpenCover_Profiler_Instrumentation"), instrumentation, 1024);
-    ATLTRACE(_T("    ::Initialize(...) => instrumentation = %s"), instrumentation);
+    ATLTRACE(_T("    ::Initialize(...) => instrumentation = %s\n"), instrumentation);
 
     TCHAR threshold[1024] = {0};
     ::GetEnvironmentVariable(_T("OpenCover_Profiler_Threshold"), threshold, 1024);
     m_threshold = _tcstoul(threshold, NULL, 10);
-    ATLTRACE(_T("    ::Initialize(...) => threshold = %ul"), m_threshold);
+    ATLTRACE(_T("    ::Initialize(...) => threshold = %ul\n"), m_threshold);
 
     TCHAR tracebyTest[1024] = {0};
     ::GetEnvironmentVariable(_T("OpenCover_Profiler_TraceByTest"), tracebyTest, 1024);
     m_tracingEnabled = _tcslen(tracebyTest) != 0;
-	ATLTRACE(_T("    ::Initialize(...) => tracingEnabled = %s (%s)"), m_tracingEnabled ? _T("true") : _T("false"), tracebyTest);
+	ATLTRACE(_T("    ::Initialize(...) => tracingEnabled = %s (%s)"), m_tracingEnabled ? _T("true") : _T("false\n"), tracebyTest);
 
 
     m_useOldStyle = (tstring(instrumentation) == _T("oldSchool"));
 
     if (!m_host.Initialise(key, ns, szExeName))
     {
-        RELTRACE(_T("    ::Initialize => Profiler will not run for this process."));
+        RELTRACE(_T("    ::Initialize => Profiler will not run for this process.\n"));
         return E_FAIL;
     }
 
@@ -125,7 +125,7 @@ HRESULT CCodeCoverage::OpenCoverInitialise(IUnknown *pICorProfilerInfoUnk){
         _FunctionEnter2, _FunctionLeave2, _FunctionTailcall2), 
         _T("    ::Initialize(...) => SetEnterLeaveFunctionHooks2 => 0x%X"));
 #endif
-    RELTRACE(_T("::Initialize - Done!"));
+    RELTRACE(_T("::Initialize - Done!\n"));
     
     return S_OK; 
 }
@@ -148,7 +148,7 @@ DWORD CCodeCoverage::AppendProfilerEventMask(DWORD currentEventMask)
 #ifndef _TOOLSETV71
 	if (m_profilerInfo4 != NULL)
 	{
-		ATLTRACE(_T("    ::Initialize (m_profilerInfo4 OK)"));
+		ATLTRACE(_T("    ::Initialize (m_profilerInfo4 OK)\n"));
 		dwMask |= COR_PRF_DISABLE_ALL_NGEN_IMAGES;
 	}
 #endif
@@ -161,7 +161,7 @@ DWORD CCodeCoverage::AppendProfilerEventMask(DWORD currentEventMask)
 /// <summary>Handle <c>ICorProfilerCallback::Shutdown</c></summary>
 HRESULT STDMETHODCALLTYPE CCodeCoverage::Shutdown( void) 
 { 
-    RELTRACE(_T("::Shutdown - Starting"));
+    RELTRACE(_T("::Shutdown - Starting\n"));
 
     if (m_chainedProfiler != NULL)
 		m_chainedProfiler->Shutdown();
@@ -170,7 +170,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::Shutdown( void)
 
     WCHAR szExeName[MAX_PATH];
     GetModuleFileNameW(NULL, szExeName, MAX_PATH);
-    RELTRACE(_T("::Shutdown - Nothing left to do but return S_OK(%s)"), szExeName);
+    RELTRACE(_T("::Shutdown - Nothing left to do but return S_OK(%s)\n"), szExeName);
     g_pProfiler = NULL;
     return S_OK; 
 }
@@ -233,14 +233,14 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ModuleAttachedToAssembly(
 
     std::wstring modulePath = GetModulePath(moduleId);
     std::wstring assemblyName = GetAssemblyName(assemblyId);
-    /*ATLTRACE(_T("::ModuleAttachedToAssembly(...) => (%X => %s, %X => %s)"), 
+    /*ATLTRACE(_T("::ModuleAttachedToAssembly(...) => (%X => %s, %X => %s)\n"), 
         moduleId, W2CT(modulePath.c_str()), 
         assemblyId, W2CT(assemblyName.c_str()));*/
     m_allowModules[modulePath] = m_host.TrackAssembly((LPWSTR)modulePath.c_str(), (LPWSTR)assemblyName.c_str());
     m_allowModulesAssemblyMap[modulePath] = assemblyName;
 
     if (m_allowModules[modulePath]){
-        ATLTRACE(_T("::ModuleAttachedToAssembly(...) => (%X => %s, %X => %s)"),
+        ATLTRACE(_T("::ModuleAttachedToAssembly(...) => (%X => %s, %X => %s)\n"),
             moduleId, W2CT(modulePath.c_str()),
             assemblyId, W2CT(assemblyName.c_str()));
     }
@@ -268,7 +268,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::JITCompilationStarted(
 
         if (m_allowModules[modulePath])
         {
-            ATLTRACE(_T("::JITCompilationStarted(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(modulePath.c_str()));
+            ATLTRACE(_T("::JITCompilationStarted(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(modulePath.c_str()));
 
             std::vector<SequencePoint> seqPoints;
             std::vector<BranchPoint> brPoints;
@@ -288,7 +288,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::JITCompilationStarted(
                     Method instumentedMethod(pMethod);
                     instumentedMethod.IncrementStackSize(2);
 
-                    ATLTRACE(_T("::JITCompilationStarted(...) => Instrumenting..."));
+                    ATLTRACE(_T("::JITCompilationStarted(...) => Instrumenting...\n"));
                     //seqPoints.clear();
                     //brPoints.clear();
 

--- a/main/OpenCover.Profiler/CodeCoverage_Cuckoo.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage_Cuckoo.cpp
@@ -37,7 +37,7 @@ HRESULT CCodeCoverage::RegisterCuckoos(ModuleID moduleId){
 	mdTypeDef systemObject = mdTokenNil;
 	if (S_OK == metaDataImport->FindTypeDefByName(L"System.Object", mdTokenNil, &systemObject))
 	{
-		RELTRACE(_T("::ModuleLoadFinished(...) => Adding methods to mscorlib..."));
+		RELTRACE(_T("::ModuleLoadFinished(...) => Adding methods to mscorlib...\n"));
 		mdMethodDef systemObjectCtor;
 		COM_FAIL_MSG_RETURN_ERROR(metaDataImport->FindMethod(systemObject, L".ctor",
 			ctorCallSignature, sizeof(ctorCallSignature), &systemObjectCtor),
@@ -122,7 +122,7 @@ HRESULT CCodeCoverage::RegisterCuckoos(ModuleID moduleId){
 		COM_FAIL_MSG_RETURN_ERROR(metaDataEmit->DefineCustomAttribute(m_cuckooSafeToken, attributeCtor, NULL, 0, &customAttr),
 			_T("    ::ModuleLoadFinished(...) => DefineCustomAttribute => 0x%X"));
 
-		RELTRACE(_T("::ModuleLoadFinished(...) => Added methods to mscorlib"));
+		RELTRACE(_T("::ModuleLoadFinished(...) => Added methods to mscorlib\n"));
 	}
 
 	return S_OK;
@@ -130,7 +130,7 @@ HRESULT CCodeCoverage::RegisterCuckoos(ModuleID moduleId){
 
 mdMemberRef CCodeCoverage::RegisterSafeCuckooMethod(ModuleID moduleId)
 {
-	ATLTRACE(_T("::RegisterSafeCuckooMethod(%X) => %s"), moduleId, CUCKOO_SAFE_METHOD_NAME);
+	ATLTRACE(_T("::RegisterSafeCuckooMethod(%X) => %s\n"), moduleId, CUCKOO_SAFE_METHOD_NAME);
 
 	// for modules we are going to instrument add our reference to the method marked 
 	// with the SecuritySafeCriticalAttribute
@@ -160,7 +160,7 @@ mdMemberRef CCodeCoverage::RegisterSafeCuckooMethod(ModuleID moduleId)
 /// <remarks>This method makes the call into the profiler</remarks>
 HRESULT CCodeCoverage::AddCriticalCuckooBody(ModuleID moduleId)
 {
-	ATLTRACE(_T("::AddCriticalCuckooBody => Adding VisitedCritical..."));
+	ATLTRACE(_T("::AddCriticalCuckooBody => Adding VisitedCritical...\n"));
 
 	mdSignature pvsig = GetMethodSignatureToken_I4(moduleId);
 	void(__fastcall *pt)(ULONG) = GetInstrumentPointVisit();
@@ -181,7 +181,7 @@ HRESULT CCodeCoverage::AddCriticalCuckooBody(ModuleID moduleId)
 
 	InstrumentMethodWith(moduleId, m_cuckooCriticalToken, instructions);
 
-	ATLTRACE(_T("::AddCriticalCuckooBody => Adding VisitedCritical - Done!"));
+	ATLTRACE(_T("::AddCriticalCuckooBody => Adding VisitedCritical - Done!\n"));
 
 	return S_OK;
 }
@@ -190,7 +190,7 @@ HRESULT CCodeCoverage::AddCriticalCuckooBody(ModuleID moduleId)
 /// <remarks>Calls the method that is marked with the SecurityCriticalAttribute</remarks>
 HRESULT CCodeCoverage::AddSafeCuckooBody(ModuleID moduleId)
 {
-	ATLTRACE(_T("::AddSafeCuckooBody => Adding SafeVisited..."));
+	ATLTRACE(_T("::AddSafeCuckooBody => Adding SafeVisited...\n"));
 
 	BYTE data[] = { (0x01 << 2) | CorILMethod_TinyFormat, CEE_RET };
 	Method criticalMethod((IMAGE_COR_ILMETHOD*)data);
@@ -203,7 +203,7 @@ HRESULT CCodeCoverage::AddSafeCuckooBody(ModuleID moduleId)
 
 	InstrumentMethodWith(moduleId, m_cuckooSafeToken, instructions);
 
-	ATLTRACE(_T("::AddSafeCuckooBody => Adding SafeVisited - Done!"));
+	ATLTRACE(_T("::AddSafeCuckooBody => Adding SafeVisited - Done!\n"));
 
 	return S_OK;
 }

--- a/main/OpenCover.Profiler/CodeCoverage_ProfilerInfo.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage_ProfilerInfo.cpp
@@ -172,7 +172,7 @@ std::wstring CCodeCoverage::GetTypeAndMethodName(FunctionID functionId)
 	methodName += L"::";
 	methodName += szMethodName;
 
-	//ATLTRACE(_T("::GetTypeAndMethodName(%s)"), W2CT(methodName.c_str()));
+	//ATLTRACE(_T("::GetTypeAndMethodName(%s)\n"), W2CT(methodName.c_str()));
 
 	return methodName;
 }

--- a/main/OpenCover.Profiler/CodeCoverage_Support.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage_Support.cpp
@@ -62,7 +62,7 @@ LPSAFEARRAY GetInjectedDllAsSafeArray()
 
 EXTERN_C HRESULT STDAPICALLTYPE LoadOpenCoverSupportAssembly(IUnknown *pUnk)
 {
-	ATLTRACE(_T("****LoadInjectorAssembly - Start****"));
+	ATLTRACE(_T("****LoadInjectorAssembly - Start****\n"));
 
 	CComPtr<_AppDomain> pAppDomain;
 	HRESULT hr = pUnk->QueryInterface(__uuidof(_AppDomain), (void**)&pAppDomain);
@@ -86,7 +86,7 @@ EXTERN_C HRESULT STDAPICALLTYPE LoadOpenCoverSupportAssembly(IUnknown *pUnk)
 
     hr = pDomainHelper->AddResolveEventHandler();
 	ATLASSERT(hr == S_OK);
-	ATLTRACE(_T("****LoadInjectorAssembly - End****"));
+	ATLTRACE(_T("****LoadInjectorAssembly - End****\n"));
 
 	return S_OK;
 }
@@ -98,13 +98,13 @@ HRESULT CCodeCoverage::OpenCoverSupportInitialize(
 	::GetEnvironmentVariable(_T("CHAIN_EXTERNAL_PROFILER"), ext, 1024);
 	if (ext[0] != 0)
 	{
-		ATLTRACE(_T("::OpenCoverSupportInitialize"));
+		ATLTRACE(_T("::OpenCoverSupportInitialize\n"));
 
-		ATLTRACE(_T("    ::Initialize(...) => ext = %s"), ext);
+		ATLTRACE(_T("    ::Initialize(...) => ext = %s\n"), ext);
 
 		TCHAR loc[1024] = { 0 };
 		::GetEnvironmentVariable(_T("CHAIN_EXTERNAL_PROFILER_LOCATION"), loc, 1024);
-		ATLTRACE(_T("    ::Initialize(...) => loc = %s"), loc);
+		ATLTRACE(_T("    ::Initialize(...) => loc = %s\n"), loc);
 
 		CLSID clsid;
 		HRESULT hr = CLSIDFromString(T2OLE(ext), &clsid);
@@ -134,7 +134,7 @@ HRESULT CCodeCoverage::OpenCoverSupportInitialize(
 
 		hr = m_chainedProfiler->Initialize(m_infoHook);
 
-		ATLTRACE(_T("  ::OpenCoverSupportInitialize => fakes = 0x%X"), hr);
+		ATLTRACE(_T("  ::OpenCoverSupportInitialize => fakes = 0x%X\n"), hr);
 	}
 	
 	return S_OK;
@@ -360,7 +360,7 @@ void CCodeCoverage::InstrumentTestToolsUITesting(FunctionID functionId, mdToken 
 
         if (APPLICATIONUNDERTEST_CCTOR == typeMethodName)
         {
-            ATLTRACE(_T("::InstrumentTestToolsUITesting(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
+            ATLTRACE(_T("::InstrumentTestToolsUITesting(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
 
             mdMethodDef invokeAttach = CreatePInvokeHook(moduleId);
             InstructionList instructions;
@@ -374,7 +374,7 @@ void CCodeCoverage::InstrumentTestToolsUITesting(FunctionID functionId, mdToken 
 
         if (APPLICATIONUNDERTEST_START == typeMethodName)
         {
-            ATLTRACE(_T("::InstrumentTestToolsUITesting(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
+            ATLTRACE(_T("::InstrumentTestToolsUITesting(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
 
             mdMemberRef memberRef = GetUITestingHelperMethodRef(_T("PropagateRequiredEnvironmentVariables"), moduleId);
             InstructionList instructions;
@@ -395,7 +395,7 @@ void CCodeCoverage::InstrumentTestPlatformUtilities(FunctionID functionId, mdTok
 
         if (DEFAULTTESTEXECUTOR_CTOR == typeMethodName)
         {
-            ATLTRACE(_T("::InstrumentTestPlatformUtilities(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
+            ATLTRACE(_T("::InstrumentTestPlatformUtilities(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
 
             mdMethodDef invokeAttach = CreatePInvokeHook(moduleId);
             InstructionList instructions;
@@ -409,7 +409,7 @@ void CCodeCoverage::InstrumentTestPlatformUtilities(FunctionID functionId, mdTok
 
         if (DEFAULTTESTEXECUTOR_LAUNCHPROCESS == typeMethodName)
         {
-            ATLTRACE(_T("::InstrumentTestPlatformUtilities(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
+            ATLTRACE(_T("::InstrumentTestPlatformUtilities(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
 
             mdMemberRef memberRef = GetFakesHelperMethodRef(_T("LoadOpenCoverProfilerInstead"), moduleId);
             InstructionList instructions;
@@ -430,7 +430,7 @@ void CCodeCoverage::InstrumentTestPlatformTestExecutor(FunctionID functionId, md
 
         if (TESTEXECUTORMAIN_CTOR == typeMethodName)
         {
-            ATLTRACE(_T("::InstrumentTestPlatformTestExecutor(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
+            ATLTRACE(_T("::InstrumentTestPlatformTestExecutor(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
 
             mdMethodDef invokeAttach = CreatePInvokeHook(moduleId);
 
@@ -445,7 +445,7 @@ void CCodeCoverage::InstrumentTestPlatformTestExecutor(FunctionID functionId, md
 
         if (TESTEXECUTORMAIN_RUN == typeMethodName)
         {
-            ATLTRACE(_T("::InstrumentTestPlatformTestExecutor(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
+            ATLTRACE(_T("::InstrumentTestPlatformTestExecutor(%X, ...) => %d, %X => %s\n"), functionId, functionToken, moduleId, W2CT(typeMethodName.c_str()));
 
             mdMemberRef memberRef = GetFakesHelperMethodRef(_T("PretendWeLoadedFakesProfiler"), moduleId);
             InstructionList instructions;

--- a/main/OpenCover.Profiler/CodeCoverage_Thread.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage_Thread.cpp
@@ -7,7 +7,7 @@
 HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadCreated(
     /* [in] */ ThreadID threadId)
 {
-    ATLTRACE(_T("::ThreadCreated(%d)"), threadId);
+    ATLTRACE(_T("::ThreadCreated(%d)\n"), threadId);
     if (m_chainedProfiler != NULL)
         m_chainedProfiler->ThreadCreated(threadId);
     return S_OK;
@@ -16,7 +16,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadCreated(
 HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadDestroyed(
     /* [in] */ ThreadID threadId)
 {
-    ATLTRACE(_T("::ThreadDestroyed(%d)"), threadId);
+    ATLTRACE(_T("::ThreadDestroyed(%d)\n"), threadId);
     if (m_chainedProfiler != NULL)
         m_chainedProfiler->ThreadDestroyed(threadId);
 
@@ -31,7 +31,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadAssignedToOSThread(
     /* [in] */ ThreadID managedThreadId,
     /* [in] */ DWORD osThreadId)
 {
-    ATLTRACE(_T("::ThreadAssignedToOSThread(%d, %d)"), managedThreadId, osThreadId);
+    ATLTRACE(_T("::ThreadAssignedToOSThread(%d, %d)\n"), managedThreadId, osThreadId);
     if (m_chainedProfiler != NULL)
         m_chainedProfiler->ThreadAssignedToOSThread(managedThreadId, osThreadId);
 
@@ -48,7 +48,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::ThreadNameChanged(
     /* [in] */
     __in_ecount_opt(cchName)  WCHAR name[])
 {
-    ATLTRACE(_T("::ThreadNameChanged(%d, %s)"), threadId, W2T(name));
+    ATLTRACE(_T("::ThreadNameChanged(%d, %s)\n"), threadId, W2T(name));
     if (m_chainedProfiler != NULL)
         m_chainedProfiler->ThreadNameChanged(threadId, cchName, name);
     return S_OK;

--- a/main/OpenCover.Profiler/Method.cpp
+++ b/main/OpenCover.Profiler/Method.cpp
@@ -41,17 +41,17 @@ void Method::ReadMethod(IMAGE_COR_ILMETHOD* pMethod)
     COR_ILMETHOD_FAT* fatImage = (COR_ILMETHOD_FAT*)&pMethod->Fat;
     if(!fatImage->IsFat())
     {
-        ATLTRACE(_T("TINY"));
+        ATLTRACE(_T("TINY\n"));
         COR_ILMETHOD_TINY* tinyImage = (COR_ILMETHOD_TINY*)&pMethod->Tiny;
         m_header.CodeSize = tinyImage->GetCodeSize();
         pCode = tinyImage->GetCode();
-        ATLTRACE(_T("TINY(%X) => (%d + 1) : %d"), m_header.CodeSize, m_header.CodeSize, m_header.MaxStack);
+        ATLTRACE(_T("TINY(%X) => (%d + 1) : %d\n"), m_header.CodeSize, m_header.CodeSize, m_header.MaxStack);
     }
     else
     {
         memcpy(&m_header, pMethod, fatImage->Size * sizeof(DWORD));
         pCode = fatImage->GetCode();
-        ATLTRACE(_T("FAT(%X) => (%d + 12) : %d"), m_header.CodeSize, m_header.CodeSize, m_header.MaxStack);
+        ATLTRACE(_T("FAT(%X) => (%d + 12) : %d\n"), m_header.CodeSize, m_header.CodeSize, m_header.MaxStack);
     }
     SetBuffer(pCode);
     ReadBody();
@@ -437,25 +437,25 @@ void Method::ResolveBranches()
 void Method::DumpIL()
 {
 #ifdef DUMP_IL
-    ATLTRACE(_T("-+-+-+-+-+-+-+-+-+-+-+-+- START -+-+-+-+-+-+-+-+-+-+-+-+"));
+    ATLTRACE(_T("-+-+-+-+-+-+-+-+-+-+-+-+- START -+-+-+-+-+-+-+-+-+-+-+-+\n"));
     for (auto it = m_instructions.begin(); it != m_instructions.end() ; ++it)
     {
         OperationDetails &details = Operations::m_mapNameOperationDetails[(*it)->m_operation];
         if (details.operandSize == Null)
         {
-            ATLTRACE(_T("IL_%04X %s"), (*it)->m_offset, details.stringName);
+            ATLTRACE(_T("IL_%04X %s\n"), (*it)->m_offset, details.stringName);
         }
         else
         {
             if (details.operandParam == ShortInlineBrTarget || details.operandParam == InlineBrTarget)
             {
                 long offset = (*it)->m_offset + (*it)->m_branchOffsets[0] + details.length + details.operandSize;
-                ATLTRACE(_T("IL_%04X %s IL_%04X"), 
+                ATLTRACE(_T("IL_%04X %s IL_%04X\n"), 
                     (*it)->m_offset, details.stringName, offset);
             }
             else if (details.operandParam == InlineMethod || details.operandParam == InlineString)
             {
-                ATLTRACE(_T("IL_%04X %s (%02X)%02X%02X%02X"), 
+                ATLTRACE(_T("IL_%04X %s (%02X)%02X%02X%02X\n"), 
                     (*it)->m_offset, details.stringName, 
                     (BYTE)((*it)->m_operand >> 24),
                     (BYTE)((*it)->m_operand >> 16),
@@ -464,22 +464,22 @@ void Method::DumpIL()
             }
             else if (details.operandSize == Byte)
             {
-                ATLTRACE(_T("IL_%04X %s %02X"), 
+                ATLTRACE(_T("IL_%04X %s %02X\n"), 
                     (*it)->m_offset, details.stringName, (*it)->m_operand);
             }
             else if (details.operandSize == Word)
             {
-                ATLTRACE(_T("IL_%04X %s %04X"), 
+                ATLTRACE(_T("IL_%04X %s %04X\n"), 
                     (*it)->m_offset, details.stringName, (*it)->m_operand);
             }
             else if (details.operandSize == Dword)
             {
-                ATLTRACE(_T("IL_%04X %s %08X"), 
+                ATLTRACE(_T("IL_%04X %s %08X\n"), 
                     (*it)->m_offset, details.stringName, (*it)->m_operand);
             }
             else
             {
-                ATLTRACE(_T("IL_%04X %s %X"), (*it)->m_offset, details.stringName, (*it)->m_operand);
+                ATLTRACE(_T("IL_%04X %s %X\n"), (*it)->m_offset, details.stringName, (*it)->m_operand);
             }
         }
         for (std::vector<long>::iterator offsetIter = (*it)->m_branchOffsets.begin(); offsetIter != (*it)->m_branchOffsets.end() ; offsetIter++)
@@ -487,7 +487,7 @@ void Method::DumpIL()
             if ((*it)->m_operation == CEE_SWITCH)
             {
                 long offset = (*it)->m_offset + (4*(long)(*it)->m_operand) + (*offsetIter) + details.length + details.operandSize;
-                ATLTRACE(_T("    IL_%04X"), offset);
+                ATLTRACE(_T("    IL_%04X\n"), offset);
             }
         }
     }
@@ -495,7 +495,7 @@ void Method::DumpIL()
     int i = 0;
     for (auto it = m_exceptions.begin(); it != m_exceptions.end() ; ++it)
     {
-        ATLTRACE(_T("Section %d: %d %04X %04X %04X %04X %04X %08X"), 
+        ATLTRACE(_T("Section %d: %d %04X %04X %04X %04X %04X %08X\n"), 
             i++, (*it)->m_handlerType, 
             (*it)->m_tryStart != NULL ? (*it)->m_tryStart->m_offset : 0, 
             (*it)->m_tryEnd != NULL ? (*it)->m_tryEnd->m_offset : 0, 
@@ -504,7 +504,7 @@ void Method::DumpIL()
             (*it)->m_filterStart != NULL ? (*it)->m_filterStart->m_offset : 0, 
             (*it)->m_token);
     } 
-    ATLTRACE(_T("-+-+-+-+-+-+-+-+-+-+-+-+-  END  -+-+-+-+-+-+-+-+-+-+-+-+"));
+    ATLTRACE(_T("-+-+-+-+-+-+-+-+-+-+-+-+-  END  -+-+-+-+-+-+-+-+-+-+-+-+\n"));
 #endif
 }
 

--- a/main/OpenCover.Profiler/ProfilerCommunication.cpp
+++ b/main/OpenCover.Profiler/ProfilerCommunication.cpp
@@ -40,50 +40,50 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
     if (!m_mutexCommunication.IsValid()) return false;
     
     USES_CONVERSION;
-    ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Initialised mutexes => %s"), W2CT(sharedKey.c_str()));
+    ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Initialised mutexes => %s\n"), W2CT(sharedKey.c_str()));
 
     auto resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_SendData_Event_") + sharedKey);
     m_eventProfilerRequestsInformation.Initialise(resource_name.c_str());
     if (!m_eventProfilerRequestsInformation.IsValid()) {
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
         return false;
     }
 
     resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_ChunkData_Event_") + sharedKey);
     m_eventInformationReadByProfiler.Initialise(resource_name.c_str());
     if (!m_eventInformationReadByProfiler.IsValid()) {
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) = >Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) = >Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
         return false;
     }
 
     resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_ReceiveData_Event_") + sharedKey);
     m_eventInformationReadyForProfiler.Initialise(resource_name.c_str());
     if (!m_eventInformationReadyForProfiler.IsValid()) {
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
         return false;
     }
 
     resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_MemoryMapFile_") + sharedKey);
     m_memoryCommunication.OpenFileMapping(resource_name.c_str());
     if (!m_memoryCommunication.IsValid()) {
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
         return false;
     }
 
     resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_Semaphore_") + sharedKey);
     _semapore_communication.Initialise(resource_name.c_str());
     if (!_semapore_communication.IsValid()) {
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
         return false;
     }
     m_pMSG = (MSG_Union*)m_memoryCommunication.MapViewOfFile(0, 0, MAX_MSG_SIZE);
 
     hostCommunicationActive = true;
 
-    ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Initialised communication interface => %s"), W2CT(sharedKey.c_str()));
+    ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Initialised communication interface => %s\n"), W2CT(sharedKey.c_str()));
 
     if (!TrackProcess()){
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) => ProfilerCommunication => process is not be tracked"));
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) => ProfilerCommunication => process is not be tracked\n"));
         return false;
     }
 
@@ -99,12 +99,12 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
 
         memoryKey = m_key + memoryKey;
 
-        ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Re-initialising communication interface => %s"), W2CT(memoryKey.c_str()));
+        ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Re-initialising communication interface => %s\n"), W2CT(memoryKey.c_str()));
 
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_SendData_Event_") + memoryKey);
         m_eventProfilerRequestsInformation.Initialise(resource_name.c_str());
         if (!m_eventProfilerRequestsInformation.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -112,7 +112,7 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_ChunkData_Event_") + memoryKey);
         m_eventInformationReadByProfiler.Initialise(resource_name.c_str());
         if (!m_eventInformationReadByProfiler.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -120,7 +120,7 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_ReceiveData_Event_") + memoryKey);
         m_eventInformationReadyForProfiler.Initialise(resource_name.c_str());
         if (!m_eventInformationReadyForProfiler.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -128,7 +128,7 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_MemoryMapFile_") + memoryKey);
         m_memoryCommunication.OpenFileMapping(resource_name.c_str());
         if (!m_memoryCommunication.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -138,17 +138,17 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Communication_Semaphore_") + memoryKey);
         _semapore_communication.Initialise(resource_name.c_str());
         if (!_semapore_communication.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
 
-        ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Re-initialised communication interface => %s"), W2CT(memoryKey.c_str()));
+        ATLTRACE(_T("ProfilerCommunication::Initialise(...) => Re-initialised communication interface => %s\n"), W2CT(memoryKey.c_str()));
 
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Results_SendResults_Event_") + memoryKey);
         m_eventProfilerHasResults.Initialise(resource_name.c_str());
         if (!m_eventProfilerHasResults.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -156,7 +156,7 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Results_ReceiveResults_Event_") + memoryKey);
         m_eventResultsHaveBeenReceived.Initialise(resource_name.c_str());
         if (!m_eventResultsHaveBeenReceived.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -164,7 +164,7 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Results_MemoryMapFile_") + memoryKey);
         m_memoryResults.OpenFileMapping(resource_name.c_str());
         if (!m_memoryResults.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
@@ -176,12 +176,12 @@ bool ProfilerCommunication::Initialise(TCHAR *key, TCHAR *ns, TCHAR *processName
         resource_name = (m_namespace + _T("\\OpenCover_Profiler_Results_Semaphore_") + memoryKey);
         _semapore_results.Initialise(resource_name.c_str());
         if (!_semapore_results.IsValid()) {
-            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d"), W2CT(resource_name.c_str()), ::GetLastError());
+            RELTRACE(_T("ProfilerCommunication::Initialise(...) => Failed to initialise resource %s => ::GetLastError() = %d\n"), W2CT(resource_name.c_str()), ::GetLastError());
             hostCommunicationActive = false;
             return false;
         }
 
-        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Initialised results interface => %s"), W2CT(memoryKey.c_str()));
+        RELTRACE(_T("ProfilerCommunication::Initialise(...) => Initialised results interface => %s\n"), W2CT(memoryKey.c_str()));
     }
     else {
         hostCommunicationActive = false;
@@ -302,7 +302,7 @@ void ProfilerCommunication::SendVisitPoints()
         if (WAIT_OBJECT_0 != dwSignal) throw CommunicationException(dwSignal, COMM_WAIT_SHORT);
         m_eventResultsHaveBeenReceived.Reset();
     } catch (CommunicationException ex) {
-        RELTRACE(_T("ProfilerCommunication::SendVisitPoints() => Communication (Results channel) with host has failed (0x%x, %d)"), 
+        RELTRACE(_T("ProfilerCommunication::SendVisitPoints() => Communication (Results channel) with host has failed (0x%x, %d)\n"), 
 			ex.getReason(), ex.getTimeout());
         hostCommunicationActive = false;
     }
@@ -342,7 +342,7 @@ bool ProfilerCommunication::GetSequencePoints(mdToken functionToken, WCHAR* pMod
         [=, &points]()->BOOL
         {
             if (m_pMSG->getSequencePointsResponse.count > SEQ_BUFFER_SIZE){
-                RELTRACE(_T("Received an abnormal count for sequence points (%d) for token 0x%X"),
+                RELTRACE(_T("Received an abnormal count for sequence points (%d) for token 0x%X\n"),
                     m_pMSG->getSequencePointsResponse.count, functionToken);
                 points.clear();
                 return false;
@@ -379,7 +379,7 @@ bool ProfilerCommunication::GetBranchPoints(mdToken functionToken, WCHAR* pModul
         [=, &points]()->BOOL
         {
             if (m_pMSG->getBranchPointsResponse.count > BRANCH_BUFFER_SIZE){
-                RELTRACE(_T("Received an abnormal count for branch points (%d) for token 0x%X"),
+                RELTRACE(_T("Received an abnormal count for branch points (%d) for token 0x%X\n"),
                     m_pMSG->getBranchPointsResponse.count, functionToken);
                 points.clear();
                 return false;
@@ -547,12 +547,12 @@ bool ProfilerCommunication::TrackProcess(){
 
 void ProfilerCommunication::report_runtime(const std::runtime_error& re, const tstring &msg){
     USES_CONVERSION;
-    RELTRACE(_T("Runtime error: %s - %s"), msg.c_str(), A2T(re.what()));
+    RELTRACE(_T("Runtime error: %s - %s\n"), msg.c_str(), A2T(re.what()));
 }
 
 void ProfilerCommunication::report_exception(const std::exception& re, const tstring &msg){
     USES_CONVERSION;
-    RELTRACE(_T("Error occurred: %s - %s"), msg.c_str(), A2T(re.what()));
+    RELTRACE(_T("Error occurred: %s - %s\n"), msg.c_str(), A2T(re.what()));
 }
 
 template<class Action>
@@ -562,7 +562,7 @@ void ProfilerCommunication::handle_sehexception(Action action, const tstring& me
     }
     __except (GetExceptionCode() == EXCEPTION_IN_PAGE_ERROR ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
     {
-        RELTRACE(_T("SEH exception failure occured: %s - %d"),
+        RELTRACE(_T("SEH exception failure occured: %s - %d\n"),
             message.c_str(), GetExceptionCode());
     }
 }
@@ -591,7 +591,7 @@ void ProfilerCommunication::handle_exception(Action action, const tstring& messa
     catch (...)
     {
         // catch any other errors (that we have no information about)
-        RELTRACE(_T("Unknown failure occured. Possible memory corruption - %s"), message.c_str());
+        RELTRACE(_T("Unknown failure occured. Possible memory corruption - %s\n"), message.c_str());
         throw;
     }
 }
@@ -633,7 +633,7 @@ void ProfilerCommunication::RequestInformation(BR buildRequest, PR processResult
 
         m_eventInformationReadByProfiler.Set();
     } catch (CommunicationException ex) {
-        RELTRACE(_T("ProfilerCommunication::RequestInformation(...) => Communication (Chat channel - %s) with host has failed (0x%x, %d)"),  
+        RELTRACE(_T("ProfilerCommunication::RequestInformation(...) => Communication (Chat channel - %s) with host has failed (0x%x, %d)\n"),  
 			message.c_str(), ex.getReason(), ex.getTimeout());
         hostCommunicationActive = false;
     } 

--- a/main/OpenCover.Profiler/ProfilerCommunication.cpp
+++ b/main/OpenCover.Profiler/ProfilerCommunication.cpp
@@ -205,16 +205,8 @@ MSG_SendVisitPoints_Request* ProfilerCommunication::AllocateVisitMap(DWORD osThr
 }
 
 MSG_SendVisitPoints_Request* ProfilerCommunication::GetVisitMapForOSThread(ULONG osThreadID){
-    MSG_SendVisitPoints_Request * p = NULL;
-    try {
-        p = m_visitmap[osThreadID];
-        if (p == NULL)
-            p = AllocateVisitMap(osThreadID);
-    }
-    catch (...){
-        p = AllocateVisitMap(osThreadID);
-    }
-    return p;
+    ATL::CComCritSecLock<ATL::CComAutoCriticalSection> lock(m_critThreads);
+    return m_visitmap[osThreadID];
 }
 
 void ProfilerCommunication::ThreadDestroyed(ThreadID threadID){

--- a/main/OpenCover.Profiler/ProfilerInfo.cpp
+++ b/main/OpenCover.Profiler/ProfilerInfo.cpp
@@ -18,7 +18,7 @@ HRESULT STDMETHODCALLTYPE CProfilerInfo::SetEventMask(
 	expected |= COR_PRF_MONITOR_MODULE_LOADS;
     expected |= COR_PRF_ENABLE_REJIT; // VS2012 only
 
-	ATLTRACE(_T("CProfilerInfo::SetEventMask => received => 0x%X, expected 0x%X"), dwEvents, expected);
+	ATLTRACE(_T("CProfilerInfo::SetEventMask => received => 0x%X, expected 0x%X\n"), dwEvents, expected);
     ATLASSERT(expected == (dwEvents | expected)); // assert that nothing new has been added that we haven't already tested against
 
 	if (m_pProfilerHook!=NULL)

--- a/main/OpenCover.Profiler/ProfilerInfoBase.h
+++ b/main/OpenCover.Profiler/ProfilerInfoBase.h
@@ -25,7 +25,7 @@ public: // ICorProfilerInfo
 	virtual HRESULT STDMETHODCALLTYPE GetClassFromObject(
 		/* [in] */ ObjectID objectId,
 		/* [out] */ ClassID *pClassId){
-		//ATLTRACE(_T("GetClassFromObject"));
+		//ATLTRACE(_T("GetClassFromObject\n"));
 		return m_pProfilerInfo->GetClassFromObject(objectId, pClassId);
 	}
 
@@ -33,7 +33,7 @@ public: // ICorProfilerInfo
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdTypeDef typeDef,
 		/* [out] */ ClassID *pClassId){
-		//ATLTRACE(_T("GetClassFromToken"));
+		//ATLTRACE(_T("GetClassFromToken\n"));
 		return m_pProfilerInfo->GetClassFromToken(moduleId, typeDef, pClassId);
 	}
 
@@ -41,20 +41,20 @@ public: // ICorProfilerInfo
 		/* [in] */ FunctionID functionId,
 		/* [out] */ LPCBYTE *pStart,
 		/* [out] */ ULONG *pcSize){
-		//ATLTRACE(_T("GetCodeInfo"));
+		//ATLTRACE(_T("GetCodeInfo\n"));
 		return m_pProfilerInfo->GetCodeInfo(functionId, pStart, pcSize);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetEventMask(
 		/* [out] */ DWORD *pdwEvents){
-		//ATLTRACE(_T("GetEventMask"));
+		//ATLTRACE(_T("GetEventMask\n"));
 		return m_pProfilerInfo->GetEventMask(pdwEvents);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetFunctionFromIP(
 		/* [in] */ LPCBYTE ip,
 		/* [out] */ FunctionID *pFunctionId){
-		//ATLTRACE(_T("GetFunctionFromIP"));
+		//ATLTRACE(_T("GetFunctionFromIP\n"));
 		return m_pProfilerInfo->GetFunctionFromIP(ip, pFunctionId);
 	}
 
@@ -62,21 +62,21 @@ public: // ICorProfilerInfo
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdToken token,
 		/* [out] */ FunctionID *pFunctionId){
-		//ATLTRACE(_T("GetFunctionFromToken"));
+		//ATLTRACE(_T("GetFunctionFromToken\n"));
 		return m_pProfilerInfo->GetFunctionFromToken(moduleId, token, pFunctionId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetHandleFromThread(
 		/* [in] */ ThreadID threadId,
 		/* [out] */ HANDLE *phThread){
-		//ATLTRACE(_T("GetHandleFromThread"));
+		//ATLTRACE(_T("GetHandleFromThread\n"));
 		return m_pProfilerInfo->GetHandleFromThread(threadId, phThread);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetObjectSize(
 		/* [in] */ ObjectID objectId,
 		/* [out] */ ULONG *pcSize){
-		//ATLTRACE(_T("GetObjectSize"));
+		//ATLTRACE(_T("GetObjectSize\n"));
 		return m_pProfilerInfo->GetObjectSize(objectId, pcSize);
 	}
 
@@ -85,20 +85,20 @@ public: // ICorProfilerInfo
 		/* [out] */ CorElementType *pBaseElemType,
 		/* [out] */ ClassID *pBaseClassId,
 		/* [out] */ ULONG *pcRank){
-		//ATLTRACE(_T("IsArrayClass"));
+		//ATLTRACE(_T("IsArrayClass\n"));
 		return m_pProfilerInfo->IsArrayClass(classId, pBaseElemType, pBaseClassId, pcRank);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetThreadInfo(
 		/* [in] */ ThreadID threadId,
 		/* [out] */ DWORD *pdwWin32ThreadId){
-		//ATLTRACE(_T("GetThreadInfo"));
+		//ATLTRACE(_T("GetThreadInfo\n"));
 		return m_pProfilerInfo->GetThreadInfo(threadId, pdwWin32ThreadId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetCurrentThreadID(
 		/* [out] */ ThreadID *pThreadId){
-		//ATLTRACE(_T("GetCurrentThreadID"));
+		//ATLTRACE(_T("GetCurrentThreadID\n"));
 		return m_pProfilerInfo->GetCurrentThreadID(pThreadId);
 	}
 
@@ -106,7 +106,7 @@ public: // ICorProfilerInfo
 		/* [in] */ ClassID classId,
 		/* [out] */ ModuleID *pModuleId,
 		/* [out] */ mdTypeDef *pTypeDefToken){
-		//ATLTRACE(_T("GetClassIDInfo"));
+		//ATLTRACE(_T("GetClassIDInfo\n"));
 		return m_pProfilerInfo->GetClassIDInfo(classId, pModuleId, pTypeDefToken);
 	}
 
@@ -115,13 +115,13 @@ public: // ICorProfilerInfo
 		/* [out] */ ClassID *pClassId,
 		/* [out] */ ModuleID *pModuleId,
 		/* [out] */ mdToken *pToken){
-		//ATLTRACE(_T("GetFunctionInfo"));
+		//ATLTRACE(_T("GetFunctionInfo\n"));
 		return m_pProfilerInfo->GetFunctionInfo(functionId, pClassId, pModuleId, pToken);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetEventMask(
 		/* [in] */ DWORD dwEvents){
-		ATLTRACE(_T("CProfilerInfoBase::SetEventMask(0x%X)"), dwEvents);
+		ATLTRACE(_T("CProfilerInfoBase::SetEventMask(0x%X)\n"), dwEvents);
 		return m_pProfilerInfo->SetEventMask(dwEvents);
 	}
 
@@ -129,13 +129,13 @@ public: // ICorProfilerInfo
 		/* [in] */ FunctionEnter *pFuncEnter,
 		/* [in] */ FunctionLeave *pFuncLeave,
 		/* [in] */ FunctionTailcall *pFuncTailcall){
-		//ATLTRACE(_T("SetEnterLeaveFunctionHooks"));
+		//ATLTRACE(_T("SetEnterLeaveFunctionHooks\n"));
 		return m_pProfilerInfo->SetEnterLeaveFunctionHooks(pFuncEnter, pFuncLeave, pFuncTailcall);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetFunctionIDMapper(
 		/* [in] */ FunctionIDMapper *pFunc){
-		//ATLTRACE(_T("SetFunctionIDMapper"));
+		//ATLTRACE(_T("SetFunctionIDMapper\n"));
 		return m_pProfilerInfo->SetFunctionIDMapper(pFunc);
 	}
 
@@ -144,7 +144,7 @@ public: // ICorProfilerInfo
 		/* [in] */ REFIID riid,
 		/* [out] */ IUnknown **ppImport,
 		/* [out] */ mdToken *pToken){
-		//ATLTRACE(_T("GetTokenAndMetaDataFromFunction"));
+		//ATLTRACE(_T("GetTokenAndMetaDataFromFunction\n"));
 		return m_pProfilerInfo->GetTokenAndMetaDataFromFunction(functionId, riid, ppImport, pToken);
 	}
 
@@ -156,7 +156,7 @@ public: // ICorProfilerInfo
 		/* [annotation][out] */
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
 		/* [out] */ AssemblyID *pAssemblyId){
-		//ATLTRACE(_T("GetModuleInfo"));
+		//ATLTRACE(_T("GetModuleInfo\n"));
 		return m_pProfilerInfo->GetModuleInfo(moduleId, ppBaseLoadAddress, cchName, pcchName, szName, pAssemblyId);
 	}
 
@@ -165,7 +165,7 @@ public: // ICorProfilerInfo
 		/* [in] */ DWORD dwOpenFlags,
 		/* [in] */ REFIID riid,
 		/* [out] */ IUnknown **ppOut){
-		//ATLTRACE(_T("GetModuleMetaData"));
+		//ATLTRACE(_T("GetModuleMetaData\n"));
 		return m_pProfilerInfo->GetModuleMetaData(moduleId, dwOpenFlags, riid, ppOut);
 	}
 
@@ -174,14 +174,14 @@ public: // ICorProfilerInfo
 		/* [in] */ mdMethodDef methodId,
 		/* [out] */ LPCBYTE *ppMethodHeader,
 		/* [out] */ ULONG *pcbMethodSize){
-		//ATLTRACE(_T("GetILFunctionBody"));
+		//ATLTRACE(_T("GetILFunctionBody\n"));
 		return m_pProfilerInfo->GetILFunctionBody(moduleId, methodId, ppMethodHeader, pcbMethodSize);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetILFunctionBodyAllocator(
 		/* [in] */ ModuleID moduleId,
 		/* [out] */ IMethodMalloc **ppMalloc){
-		//ATLTRACE(_T("GetILFunctionBodyAllocator"));
+		//ATLTRACE(_T("GetILFunctionBodyAllocator\n"));
 		return m_pProfilerInfo->GetILFunctionBodyAllocator(moduleId, ppMalloc);
 	}
 
@@ -189,7 +189,7 @@ public: // ICorProfilerInfo
 		/* [in] */ ModuleID moduleId,
 		/* [in] */ mdMethodDef methodid,
 		/* [in] */ LPCBYTE pbNewILMethodHeader){
-		//ATLTRACE(_T("SetILFunctionBody"));
+		//ATLTRACE(_T("SetILFunctionBody\n"));
 		return m_pProfilerInfo->SetILFunctionBody(moduleId, methodid, pbNewILMethodHeader);
 	}
 
@@ -200,7 +200,7 @@ public: // ICorProfilerInfo
 		/* [annotation][out] */
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
 		/* [out] */ ProcessID *pProcessId){
-		//ATLTRACE(_T("GetAppDomainInfo"));
+		//ATLTRACE(_T("GetAppDomainInfo\n"));
 		return m_pProfilerInfo->GetAppDomainInfo(appDomainId, cchName, pcchName, szName, pProcessId);
 	}
 
@@ -212,18 +212,18 @@ public: // ICorProfilerInfo
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
 		/* [out] */ AppDomainID *pAppDomainId,
 		/* [out] */ ModuleID *pModuleId){
-		//ATLTRACE(_T("GetAssemblyInfo"));
+		//ATLTRACE(_T("GetAssemblyInfo\n"));
 		return m_pProfilerInfo->GetAssemblyInfo(assemblyId, cchName, pcchName, szName, pAppDomainId, pModuleId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetFunctionReJIT(
 		/* [in] */ FunctionID functionId){
-		//ATLTRACE(_T("SetFunctionReJIT"));
+		//ATLTRACE(_T("SetFunctionReJIT\n"));
 		return m_pProfilerInfo->SetFunctionReJIT(functionId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE ForceGC(void){
-		//ATLTRACE(_T("GetClassFromObject"));
+		//ATLTRACE(_T("GetClassFromObject\n"));
 		return m_pProfilerInfo->ForceGC();
 	}
 
@@ -232,39 +232,39 @@ public: // ICorProfilerInfo
 		/* [in] */ BOOL fStartJit,
 		/* [in] */ ULONG cILMapEntries,
 		/* [size_is][in] */ COR_IL_MAP rgILMapEntries[]){
-		//ATLTRACE(_T("SetILInstrumentedCodeMap"));
+		//ATLTRACE(_T("SetILInstrumentedCodeMap\n"));
 		return m_pProfilerInfo->SetILInstrumentedCodeMap(functionId, fStartJit, cILMapEntries, rgILMapEntries);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetInprocInspectionInterface(
 		/* [out] */ IUnknown **ppicd){
-		//ATLTRACE(_T("GetInprocInspectionInterface"));
+		//ATLTRACE(_T("GetInprocInspectionInterface\n"));
 		return m_pProfilerInfo->GetInprocInspectionInterface(ppicd);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetInprocInspectionIThisThread(
 		/* [out] */ IUnknown **ppicd){
-		//ATLTRACE(_T("GetInprocInspectionIThisThread"));
+		//ATLTRACE(_T("GetInprocInspectionIThisThread\n"));
 		return m_pProfilerInfo->GetInprocInspectionIThisThread(ppicd);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetThreadContext(
 		/* [in] */ ThreadID threadId,
 		/* [out] */ ContextID *pContextId){
-		//ATLTRACE(_T("GetThreadContext"));
+		//ATLTRACE(_T("GetThreadContext\n"));
 		return m_pProfilerInfo->GetThreadContext(threadId, pContextId);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE BeginInprocDebugging(
 		/* [in] */ BOOL fThisThreadOnly,
 		/* [out] */ DWORD *pdwProfilerContext){
-		//ATLTRACE(_T("BeginInprocDebugging"));
+		//ATLTRACE(_T("BeginInprocDebugging\n"));
 		return m_pProfilerInfo->BeginInprocDebugging(fThisThreadOnly, pdwProfilerContext);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EndInprocDebugging(
 		/* [in] */ DWORD dwProfilerContext){
-		//ATLTRACE(_T("EndInprocDebugging"));
+		//ATLTRACE(_T("EndInprocDebugging\n"));
 		return m_pProfilerInfo->EndInprocDebugging(dwProfilerContext);
 	}
 
@@ -273,7 +273,7 @@ public: // ICorProfilerInfo
 		/* [in] */ ULONG32 cMap,
 		/* [out] */ ULONG32 *pcMap,
 		/* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[]){
-		//ATLTRACE(_T("GetILToNativeMapping"));
+		//ATLTRACE(_T("GetILToNativeMapping\n"));
 		return m_pProfilerInfo->GetILToNativeMapping(functionId, cMap, pcMap, map);
 	}
 
@@ -285,7 +285,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ void *clientData,
 		/* [size_is][in] */ BYTE context[],
 		/* [in] */ ULONG32 contextSize){
-		//ATLTRACE(_T("DoStackSnapshot"));
+		//ATLTRACE(_T("DoStackSnapshot\n"));
 		return m_pProfilerInfo2->DoStackSnapshot(thread, callback, infoFlags, clientData, context, contextSize);
 	}
 
@@ -293,7 +293,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ FunctionEnter2 *pFuncEnter,
 		/* [in] */ FunctionLeave2 *pFuncLeave,
 		/* [in] */ FunctionTailcall2 *pFuncTailcall){
-		//ATLTRACE(_T("SetEnterLeaveFunctionHooks2"));
+		//ATLTRACE(_T("SetEnterLeaveFunctionHooks2\n"));
 		return m_pProfilerInfo2->SetEnterLeaveFunctionHooks2(pFuncEnter, pFuncLeave, pFuncTailcall);
 	}
 
@@ -306,7 +306,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 cTypeArgs,
 		/* [out] */ ULONG32 *pcTypeArgs,
 		/* [out] */ ClassID typeArgs[]){
-		//ATLTRACE(_T("GetFunctionInfo2"));
+		//ATLTRACE(_T("GetFunctionInfo2\n"));
 		return m_pProfilerInfo2->GetFunctionInfo2(funcId, frameInfo, pClassId, pModuleId, pToken, cTypeArgs, pcTypeArgs, typeArgs);
 	}
 
@@ -314,7 +314,7 @@ public: //ICorProfilerInfo2
 		/* [out] */ ULONG *pBufferLengthOffset,
 		/* [out] */ ULONG *pStringLengthOffset,
 		/* [out] */ ULONG *pBufferOffset){
-		//ATLTRACE(_T("GetStringLayout"));
+		//ATLTRACE(_T("GetStringLayout\n"));
 		return m_pProfilerInfo2->GetStringLayout(pBufferLengthOffset, pStringLengthOffset, pBufferOffset);
 	}
 
@@ -324,7 +324,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG cFieldOffset,
 		/* [out] */ ULONG *pcFieldOffset,
 		/* [out] */ ULONG *pulClassSize){
-		//ATLTRACE(_T("GetClassLayout"));
+		//ATLTRACE(_T("GetClassLayout\n"));
 		return m_pProfilerInfo2->GetClassLayout(classID, rFieldOffset, cFieldOffset, pcFieldOffset, pulClassSize);
 	}
 
@@ -336,7 +336,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 cNumTypeArgs,
 		/* [out] */ ULONG32 *pcNumTypeArgs,
 		/* [out] */ ClassID typeArgs[]){
-		//ATLTRACE(_T("GetClassIDInfo2"));
+		//ATLTRACE(_T("GetClassIDInfo2\n"));
 		return m_pProfilerInfo2->GetClassIDInfo2(classId, pModuleId, pTypeDefToken, pParentClassId, cNumTypeArgs, pcNumTypeArgs, typeArgs);
 	}
 
@@ -345,7 +345,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 cCodeInfos,
 		/* [out] */ ULONG32 *pcCodeInfos,
 		/* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[]){
-		//ATLTRACE(_T("GetCodeInfo2"));
+		//ATLTRACE(_T("GetCodeInfo2\n"));
 		return m_pProfilerInfo2->GetCodeInfo2(functionID, cCodeInfos, pcCodeInfos, codeInfos);
 	}
 
@@ -355,7 +355,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 cTypeArgs,
 		/* [size_is][in] */ ClassID typeArgs[],
 		/* [out] */ ClassID *pClassID){
-		//ATLTRACE(_T("GetClassFromTokenAndTypeArgs"));
+		//ATLTRACE(_T("GetClassFromTokenAndTypeArgs\n"));
 		return m_pProfilerInfo2->GetClassFromTokenAndTypeArgs(moduleID, typeDef, cTypeArgs, typeArgs, pClassID);
 	}
 
@@ -366,14 +366,14 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG32 cTypeArgs,
 		/* [size_is][in] */ ClassID typeArgs[],
 		/* [out] */ FunctionID *pFunctionID){
-		//ATLTRACE(_T("GetFunctionFromTokenAndTypeArgs"));
+		//ATLTRACE(_T("GetFunctionFromTokenAndTypeArgs\n"));
 		return m_pProfilerInfo2->GetFunctionFromTokenAndTypeArgs(moduleID, funcDef, classId, cTypeArgs, typeArgs, pFunctionID);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EnumModuleFrozenObjects(
 		/* [in] */ ModuleID moduleID,
 		/* [out] */ ICorProfilerObjectEnum **ppEnum){
-		//ATLTRACE(_T("GetClassFromObject"));
+		//ATLTRACE(_T("GetClassFromObject\n"));
 		return m_pProfilerInfo2->EnumModuleFrozenObjects(moduleID, ppEnum);
 	}
 
@@ -383,21 +383,21 @@ public: //ICorProfilerInfo2
 		/* [size_is][out] */ ULONG32 pDimensionSizes[],
 		/* [size_is][out] */ int pDimensionLowerBounds[],
 		/* [out] */ BYTE **ppData){
-		//ATLTRACE(_T("GetArrayObjectInfo"));
+		//ATLTRACE(_T("GetArrayObjectInfo\n"));
 		return m_pProfilerInfo2->GetArrayObjectInfo(objectId, cDimensions, pDimensionSizes, pDimensionLowerBounds, ppData);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetBoxClassLayout(
 		/* [in] */ ClassID classId,
 		/* [out] */ ULONG32 *pBufferOffset){
-		//ATLTRACE(_T("GetBoxClassLayout"));
+		//ATLTRACE(_T("GetBoxClassLayout\n"));
 		return m_pProfilerInfo2->GetBoxClassLayout(classId, pBufferOffset);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetThreadAppDomain(
 		/* [in] */ ThreadID threadId,
 		/* [out] */ AppDomainID *pAppDomainId){
-		//ATLTRACE(_T("GetThreadAppDomain"));
+		//ATLTRACE(_T("GetThreadAppDomain\n"));
 		return m_pProfilerInfo2->GetThreadAppDomain(threadId, pAppDomainId);
 	}
 
@@ -405,7 +405,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
 		/* [out] */ void **ppAddress){
-		//ATLTRACE(_T("GetRVAStaticAddress"));
+		//ATLTRACE(_T("GetRVAStaticAddress\n"));
 		return m_pProfilerInfo2->GetRVAStaticAddress(classId, fieldToken, ppAddress);
 	}
 
@@ -414,7 +414,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ AppDomainID appDomainId,
 		/* [out] */ void **ppAddress){
-		//ATLTRACE(_T("GetAppDomainStaticAddress"));
+		//ATLTRACE(_T("GetAppDomainStaticAddress\n"));
 		return m_pProfilerInfo2->GetAppDomainStaticAddress(classId, fieldToken, appDomainId, ppAddress);
 	}
 
@@ -423,7 +423,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ ThreadID threadId,
 		/* [out] */ void **ppAddress){
-		//ATLTRACE(_T("GetThreadStaticAddress"));
+		//ATLTRACE(_T("GetThreadStaticAddress\n"));
 		return m_pProfilerInfo2->GetThreadStaticAddress(classId, fieldToken, threadId, ppAddress);
 	}
 
@@ -432,7 +432,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ mdFieldDef fieldToken,
 		/* [in] */ ContextID contextId,
 		/* [out] */ void **ppAddress){
-		//ATLTRACE(_T("GetContextStaticAddress"));
+		//ATLTRACE(_T("GetContextStaticAddress\n"));
 		return m_pProfilerInfo2->GetContextStaticAddress(classId, fieldToken, contextId, ppAddress);
 	}
 
@@ -440,7 +440,7 @@ public: //ICorProfilerInfo2
 		/* [in] */ ClassID classId,
 		/* [in] */ mdFieldDef fieldToken,
 		/* [out] */ COR_PRF_STATIC_TYPE *pFieldInfo){
-		//ATLTRACE(_T("GetStaticFieldInfo"));
+		//ATLTRACE(_T("GetStaticFieldInfo\n"));
 		return m_pProfilerInfo2->GetStaticFieldInfo(classId, fieldToken, pFieldInfo);
 	}
 
@@ -448,47 +448,47 @@ public: //ICorProfilerInfo2
 		/* [in] */ ULONG cObjectRanges,
 		/* [out] */ ULONG *pcObjectRanges,
 		/* [length_is][size_is][out] */ COR_PRF_GC_GENERATION_RANGE ranges[]){
-		//ATLTRACE(_T("GetGenerationBounds"));
+		//ATLTRACE(_T("GetGenerationBounds\n"));
 		return m_pProfilerInfo2->GetGenerationBounds(cObjectRanges, pcObjectRanges, ranges);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetObjectGeneration(
 		/* [in] */ ObjectID objectId,
 		/* [out] */ COR_PRF_GC_GENERATION_RANGE *range){
-		//ATLTRACE(_T("GetObjectGeneration"));
+		//ATLTRACE(_T("GetObjectGeneration\n"));
 		return m_pProfilerInfo2->GetObjectGeneration(objectId, range);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetNotifiedExceptionClauseInfo(
 		/* [out] */ COR_PRF_EX_CLAUSE_INFO *pinfo){
-		//ATLTRACE(_T("GetNotifiedExceptionClauseInfo"));
+		//ATLTRACE(_T("GetNotifiedExceptionClauseInfo\n"));
 		return m_pProfilerInfo2->GetNotifiedExceptionClauseInfo(pinfo);
 	}
 
 public: // ICorProfilerInfo3
 	virtual HRESULT STDMETHODCALLTYPE EnumJITedFunctions(
 		/* [out] */ ICorProfilerFunctionEnum **ppEnum){
-		//ATLTRACE(_T("EnumJITedFunctions"));
+		//ATLTRACE(_T("EnumJITedFunctions\n"));
 		return m_pProfilerInfo3->EnumJITedFunctions(ppEnum);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE RequestProfilerDetach(
 		/* [in] */ DWORD dwExpectedCompletionMilliseconds){
-		//ATLTRACE(_T("RequestProfilerDetach"));
+		//ATLTRACE(_T("RequestProfilerDetach\n"));
 		return m_pProfilerInfo3->RequestProfilerDetach(dwExpectedCompletionMilliseconds);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE SetFunctionIDMapper2(
 		/* [in] */ FunctionIDMapper2 *pFunc,
 		/* [in] */ void *clientData){
-		//ATLTRACE(_T("SetFunctionIDMapper2"));
+		//ATLTRACE(_T("SetFunctionIDMapper2\n"));
 		return m_pProfilerInfo3->SetFunctionIDMapper2(pFunc, clientData);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetStringLayout2(
 		/* [out] */ ULONG *pStringLengthOffset,
 		/* [out] */ ULONG *pBufferOffset){
-		//ATLTRACE(_T("GetStringLayout2"));
+		//ATLTRACE(_T("GetStringLayout2\n"));
 		return m_pProfilerInfo3->GetStringLayout2(pStringLengthOffset, pBufferOffset);
 	}
 
@@ -496,7 +496,7 @@ public: // ICorProfilerInfo3
 		/* [in] */ FunctionEnter3 *pFuncEnter3,
 		/* [in] */ FunctionLeave3 *pFuncLeave3,
 		/* [in] */ FunctionTailcall3 *pFuncTailcall3){
-		//ATLTRACE(_T("SetEnterLeaveFunctionHooks3"));
+		//ATLTRACE(_T("SetEnterLeaveFunctionHooks3\n"));
 		return m_pProfilerInfo3->SetEnterLeaveFunctionHooks3(pFuncEnter3, pFuncLeave3, pFuncTailcall3);
 	}
 
@@ -504,7 +504,7 @@ public: // ICorProfilerInfo3
 		/* [in] */ FunctionEnter3WithInfo *pFuncEnter3WithInfo,
 		/* [in] */ FunctionLeave3WithInfo *pFuncLeave3WithInfo,
 		/* [in] */ FunctionTailcall3WithInfo *pFuncTailcall3WithInfo){
-		//ATLTRACE(_T("SetEnterLeaveFunctionHooks3WithInfo"));
+		//ATLTRACE(_T("SetEnterLeaveFunctionHooks3WithInfo\n"));
 		return m_pProfilerInfo3->SetEnterLeaveFunctionHooks3WithInfo(pFuncEnter3WithInfo, pFuncLeave3WithInfo, pFuncTailcall3WithInfo);
 	}
 
@@ -514,7 +514,7 @@ public: // ICorProfilerInfo3
 		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo,
 		/* [out][in] */ ULONG *pcbArgumentInfo,
 		/* [size_is][out] */ COR_PRF_FUNCTION_ARGUMENT_INFO *pArgumentInfo){
-		//ATLTRACE(_T("GetFunctionEnter3Info"));
+		//ATLTRACE(_T("GetFunctionEnter3Info\n"));
 		return m_pProfilerInfo3->GetFunctionEnter3Info(functionId, eltInfo, pFrameInfo, pcbArgumentInfo, pArgumentInfo);
 	}
 
@@ -523,7 +523,7 @@ public: // ICorProfilerInfo3
 		/* [in] */ COR_PRF_ELT_INFO eltInfo,
 		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo,
 		/* [out] */ COR_PRF_FUNCTION_ARGUMENT_RANGE *pRetvalRange){
-		//ATLTRACE(_T("GetFunctionLeave3Info"));
+		//ATLTRACE(_T("GetFunctionLeave3Info\n"));
 		return m_pProfilerInfo3->GetFunctionLeave3Info(functionId, eltInfo, pFrameInfo, pRetvalRange);
 	}
 
@@ -531,13 +531,13 @@ public: // ICorProfilerInfo3
 		/* [in] */ FunctionID functionId,
 		/* [in] */ COR_PRF_ELT_INFO eltInfo,
 		/* [out] */ COR_PRF_FRAME_INFO *pFrameInfo){
-		//ATLTRACE(_T("GetFunctionTailcall3Info"));
+		//ATLTRACE(_T("GetFunctionTailcall3Info\n"));
 		return m_pProfilerInfo3->GetFunctionTailcall3Info(functionId, eltInfo, pFrameInfo);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EnumModules(
 		/* [out] */ ICorProfilerModuleEnum **ppEnum){
-		//ATLTRACE(_T("EnumModules"));
+		//ATLTRACE(_T("EnumModules\n"));
 		return m_pProfilerInfo3->EnumModules(ppEnum);
 	}
 
@@ -552,7 +552,7 @@ public: // ICorProfilerInfo3
 		/* [out] */ ULONG *pcchVersionString,
 		/* [annotation][out] */
 		_Out_writes_to_(cchVersionString, *pcchVersionString)  WCHAR szVersionString[]){
-		//ATLTRACE(_T("GetRuntimeInformation"));
+		//ATLTRACE(_T("GetRuntimeInformation\n"));
 		return m_pProfilerInfo3->GetRuntimeInformation(pClrInstanceId, pRuntimeType, pMajorVersion,
 			pMinorVersion, pBuildNumber, pQFEVersion, cchVersionString, pcchVersionString, szVersionString);
 	}
@@ -563,7 +563,7 @@ public: // ICorProfilerInfo3
 		/* [in] */ AppDomainID appDomainId,
 		/* [in] */ ThreadID threadId,
 		/* [out] */ void **ppAddress){
-		//ATLTRACE(_T("GetThreadStaticAddress2"));
+		//ATLTRACE(_T("GetThreadStaticAddress2\n"));
 		return m_pProfilerInfo3->GetThreadStaticAddress2(classId,
 			fieldToken, appDomainId, threadId, ppAddress);
 	}
@@ -573,7 +573,7 @@ public: // ICorProfilerInfo3
 		/* [in] */ ULONG32 cAppDomainIds,
 		/* [out] */ ULONG32 *pcAppDomainIds,
 		/* [length_is][size_is][out] */ AppDomainID appDomainIds[]){
-		//ATLTRACE(_T("GetAppDomainsContainingModule"));
+		//ATLTRACE(_T("GetAppDomainsContainingModule\n"));
 		return m_pProfilerInfo3->GetAppDomainsContainingModule(moduleId,
 			cAppDomainIds, pcAppDomainIds, appDomainIds);
 	}
@@ -587,7 +587,7 @@ public: // ICorProfilerInfo3
 		_Out_writes_to_(cchName, *pcchName)  WCHAR szName[],
 		/* [out] */ AssemblyID *pAssemblyId,
 		/* [out] */ DWORD *pdwModuleFlags){
-		//ATLTRACE(_T("GetModuleInfo2"));
+		//ATLTRACE(_T("GetModuleInfo2\n"));
 		return m_pProfilerInfo3->GetModuleInfo2(moduleId, ppBaseLoadAddress, cchName,
 			pcchName, szName, pAssemblyId, pdwModuleFlags);
 	}
@@ -595,12 +595,12 @@ public: // ICorProfilerInfo3
 public: // ICorProfilerInfo4
 	virtual HRESULT STDMETHODCALLTYPE EnumThreads(
 		/* [out] */ ICorProfilerThreadEnum **ppEnum){
-		//ATLTRACE(_T("EnumThreads"));
+		//ATLTRACE(_T("EnumThreads\n"));
 		return m_pProfilerInfo4->EnumThreads(ppEnum);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE InitializeCurrentThread(void){
-		//ATLTRACE(_T("InitializeCurrentThread"));
+		//ATLTRACE(_T("InitializeCurrentThread\n"));
 		return m_pProfilerInfo4->InitializeCurrentThread();
 	}
 
@@ -608,7 +608,7 @@ public: // ICorProfilerInfo4
 		/* [in] */ ULONG cFunctions,
 		/* [size_is][in] */ ModuleID moduleIds[],
 		/* [size_is][in] */ mdMethodDef methodIds[]){
-		//ATLTRACE(_T("RequestReJIT"));
+		//ATLTRACE(_T("RequestReJIT\n"));
 		return m_pProfilerInfo4->RequestReJIT(cFunctions, moduleIds, methodIds);
 	}
 
@@ -617,7 +617,7 @@ public: // ICorProfilerInfo4
 		/* [size_is][in] */ ModuleID moduleIds[],
 		/* [size_is][in] */ mdMethodDef methodIds[],
 		/* [size_is][out] */ HRESULT status[]){
-		//ATLTRACE(_T("RequestRevert"));
+		//ATLTRACE(_T("RequestRevert\n"));
 		return m_pProfilerInfo4->RequestRevert(cFunctions, moduleIds, methodIds, status);
 	}
 
@@ -627,7 +627,7 @@ public: // ICorProfilerInfo4
 		/* [in] */ ULONG32 cCodeInfos,
 		/* [out] */ ULONG32 *pcCodeInfos,
 		/* [length_is][size_is][out] */ COR_PRF_CODE_INFO codeInfos[]){
-		//ATLTRACE(_T("GetCodeInfo3"));
+		//ATLTRACE(_T("GetCodeInfo3\n"));
 		return m_pProfilerInfo4->GetCodeInfo3(functionID, reJitId, cCodeInfos, pcCodeInfos, codeInfos);
 	}
 
@@ -635,7 +635,7 @@ public: // ICorProfilerInfo4
 		/* [in] */ LPCBYTE ip,
 		/* [out] */ FunctionID *pFunctionId,
 		/* [out] */ ReJITID *pReJitId){
-		//ATLTRACE(_T("GetFunctionFromIP2"));
+		//ATLTRACE(_T("GetFunctionFromIP2\n"));
 		return m_pProfilerInfo4->GetFunctionFromIP2(ip, pFunctionId, pReJitId);
 	}
 
@@ -644,7 +644,7 @@ public: // ICorProfilerInfo4
 		/* [in] */ ULONG cReJitIds,
 		/* [out] */ ULONG *pcReJitIds,
 		/* [length_is][size_is][out] */ ReJITID reJitIds[]){
-		//ATLTRACE(_T("GetClassFromObject"));
+		//ATLTRACE(_T("GetClassFromObject\n"));
 		return m_pProfilerInfo4->GetReJITIDs(functionId, cReJitIds, pcReJitIds, reJitIds);
 	}
 
@@ -654,20 +654,20 @@ public: // ICorProfilerInfo4
 		/* [in] */ ULONG32 cMap,
 		/* [out] */ ULONG32 *pcMap,
 		/* [length_is][size_is][out] */ COR_DEBUG_IL_TO_NATIVE_MAP map[]){
-		//ATLTRACE(_T("GetILToNativeMapping2"));
+		//ATLTRACE(_T("GetILToNativeMapping2\n"));
 		return m_pProfilerInfo4->GetILToNativeMapping2(functionId, reJitId, cMap, pcMap, map);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE EnumJITedFunctions2(
 		/* [out] */ ICorProfilerFunctionEnum **ppEnum){
-		//ATLTRACE(_T("EnumJITedFunctions2"));
+		//ATLTRACE(_T("EnumJITedFunctions2\n"));
 		return m_pProfilerInfo4->EnumJITedFunctions2(ppEnum);
 	}
 
 	virtual HRESULT STDMETHODCALLTYPE GetObjectSize2(
 		/* [in] */ ObjectID objectId,
 		/* [out] */ SIZE_T *pcSize){
-		//ATLTRACE(_T("GetObjectSize2"));
+		//ATLTRACE(_T("GetObjectSize2\n"));
 		return m_pProfilerInfo4->GetObjectSize2(objectId, pcSize);
 	}
 

--- a/main/OpenCover.Profiler/Synchronization.h
+++ b/main/OpenCover.Profiler/Synchronization.h
@@ -51,12 +51,12 @@ public:
             LONG prevCount = -1;
             if (::ReleaseSemaphore(m_hSemaphore, 1, &prevCount) && prevCount == 0){ // +1
                 if (::WaitForSingleObject(m_hSemaphore, 1000) == WAIT_TIMEOUT){     // -1
-                    RELTRACE(_T("Semaphore wait timed out => %s"), _handleName.c_str());
+                    RELTRACE(_T("Semaphore wait timed out => %s\n"), _handleName.c_str());
                     return -1;
                 }
             }
             else {
-                RELTRACE(_T("Semaphore count failed => %s, %d"), _handleName.c_str(), prevCount);
+                RELTRACE(_T("Semaphore count failed => %s, %d\n"), _handleName.c_str(), prevCount);
             }
             return prevCount;
         }


### PR DESCRIPTION
Not clear to me how to unit test this...

When OpenCover runs on a number of subprocesses, OpenCover.Console.exe could crash due to the problem in InstrumentationPoint.cs.
Additionally, some of these subprocesses could die badly (since the error occurs in the native profiler dll) because of the issue in ProfilerCommunication.cpp. With a small test exe intensive on thread creation, I could make it crash almost instantly, but of course not anymore after the fix.

I also added the apparently "normal" line feed in traces, else it would behave poorly in windbg.
