### PR TITLE
Source Connection For Compiler Generated Branches?

### DIFF
--- a/main/OpenCover.Framework/Model/SequencePoint.cs
+++ b/main/OpenCover.Framework/Model/SequencePoint.cs
@@ -37,10 +37,16 @@ namespace OpenCover.Framework.Model
         /// </summary>
         [XmlAttribute("ec")]
         public int EndColumn { get; set; }
-        
+
+        /// <summary>
+        /// Count of merged branches
+        /// </summary>
         [XmlAttribute("bec")]
         public int BranchExitsCount { get; set; }
         
+        /// <summary>
+        /// Visit count of merged branches 
+        /// </summary>
         [XmlAttribute("bev")]
         public int BranchExitsVisit { get; set; }
 

--- a/main/OpenCover.Framework/OpenCover.Framework.csproj
+++ b/main/OpenCover.Framework/OpenCover.Framework.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Symbols\CecilSymbolManager.cs" />
     <Compile Include="Symbols\ISymbolManager.cs" />
     <Compile Include="Symbols\SymbolFolder.cs" />
+    <Compile Include="Utility\CodeCoverageStringTextSource.cs" />
     <Compile Include="Utility\IPerfCounters.cs" />
     <Compile Include="Utility\PerfCounters.cs" />
   </ItemGroup>

--- a/main/OpenCover.Framework/Utility/CodeCoverageStringTextSource.cs
+++ b/main/OpenCover.Framework/Utility/CodeCoverageStringTextSource.cs
@@ -1,0 +1,254 @@
+﻿// Copyright (c) https://github.com/ddur
+// This code is distributed under MIT license
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using OpenCover.Framework.Model;
+
+namespace OpenCover.Framework.Utility
+{
+    /// <summary>StringTextSource (ReadOnly)
+	/// <remarks>Line and column counting starts at 1.</remarks>
+    /// <remarks>IDocument/ITextBuffer/ITextSource fails returning single char "{"?</remarks>
+    /// </summary>
+    public class CodeCoverageStringTextSource
+    {
+        private readonly string textSource;
+        private struct lineInfo {
+            public int Offset;
+            public int Length;
+        }
+        private readonly lineInfo[] lines;
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="source"></param>
+        public CodeCoverageStringTextSource(string source)
+        {
+            this.textSource = source;
+
+            lineInfo line;
+            var lineInfoList = new List<lineInfo>();
+            int offset = 0;
+            int counter = 0;
+            bool newLine = false;
+            bool cr = false;
+            bool lf = false;
+
+            foreach ( ushort ch in textSource ) {
+                switch (ch) {
+                    case 0xD:
+                        if (lf||cr) {
+                            newLine = true; // cr after cr|lf
+                        } else {
+                            cr = true; // cr found
+                        }
+                        break;
+                    case 0xA:
+                        if (lf) {
+                            newLine = true; // lf after lf
+                        } else {
+                            lf = true; // lf found
+                        }
+                        break;
+                    default:
+                        if (cr||lf) {
+                            newLine = true; // any non-line-end char after any line-end
+                        }
+                        break;
+                }
+                if (newLine) { // newLine detected - add line
+                    line = new lineInfo();
+                    line.Offset = offset;
+                    line.Length = counter - offset;
+                    lineInfoList.Add(line);
+                    offset = counter;
+                    cr = false;
+                    lf = false;
+                    newLine = false;
+                }
+                ++counter;
+            }
+            
+            // Add last line
+            line = new lineInfo();
+            line.Offset = offset;
+            line.Length = counter - offset;
+            lineInfoList.Add(line);
+
+            // Store to readonly field
+            lines = lineInfoList.ToArray();
+        }
+
+        /// <summary>Return text/source using SequencePoint line/col info
+        /// </summary>
+        /// <param name="sp"></param>
+        /// <returns></returns>
+        public string GetText(SequencePoint sp) {
+            return this.GetText(sp.StartLine, sp.StartColumn, sp.EndLine, sp.EndColumn );
+        }
+
+        /// <summary>Return text at Line/Column/EndLine/EndColumn position
+        /// <remarks>Line and Column counting starts at 1.</remarks>
+        /// </summary>
+        /// <param name="Line"></param>
+        /// <param name="Column"></param>
+        /// <param name="EndLine"></param>
+        /// <param name="EndColumn"></param>
+        /// <returns></returns>
+        public string GetText(int Line, int Column, int EndLine, int EndColumn) {
+
+            var text = new StringBuilder();
+            string line;
+            bool argOutOfRange;
+
+            if (Line==EndLine) {
+
+                #region One-Line request
+                line = GetLine(Line);
+
+                //Debug.Assert(!(Column < 1), "Column < 1");
+                //Debug.Assert(!(Column > EndColumn), "Column > EndColumn");
+                //Debug.Assert(!(EndColumn > line.Length + 1), string.Format ("Single Line EndColumn({0}) > line.Length({1})",EndColumn, line.Length ));
+                //Debug.Assert(!(EndColumn > line.Length + 1), line);
+
+                argOutOfRange = Column < 1
+                    ||   Column > EndColumn
+                    ||   EndColumn > line.Length;
+                if (!argOutOfRange) {
+                    text.Append(line.Substring(Column-1,EndColumn-Column));
+                }
+                #endregion
+
+            } else if (Line<EndLine) {
+
+                #region Multi-line request
+
+                #region First line
+                line = GetLine(Line);
+
+                //Debug.Assert(!(Column < 1), "Column < 1");
+                //Debug.Assert(!(Column > line.Length), string.Format ("First MultiLine EndColumn({0}) > line.Length({1})",EndColumn, line.Length ));
+
+                argOutOfRange = Column < 1
+                    ||   Column > line.Length;
+                if (!argOutOfRange) {
+                    text.Append(line.Substring(Column-1));
+                }
+                #endregion
+
+                #region More than two lines
+                for ( int lineIndex = Line+1; lineIndex < EndLine; lineIndex++ ) {
+                    text.Append ( GetLine ( lineIndex ) );
+                }
+                #endregion
+
+                #region Last line
+                line = GetLine(EndLine);
+
+                //Debug.Assert(!(EndColumn < 1), "EndColumn < 1");
+                //Debug.Assert(!(EndColumn > line.Length), string.Format ("Last MultiLine EndColumn({0}) > line.Length({1})",EndColumn, line.Length ));
+
+                argOutOfRange = EndColumn < 1
+                    ||   EndColumn > line.Length;
+                if (!argOutOfRange) {
+                    text.Append(line.Substring(0,EndColumn));
+                }
+                #endregion
+
+                #endregion
+
+            } else {
+                //Debug.Fail("Line > EndLine");
+            }
+            return text.ToString();
+        }
+
+        /// <summary>
+        /// Return number of lines in source
+        /// </summary>
+        public int LinesCount {
+            get {
+                return lines.Length;
+            }
+        }
+
+        /// <summary>Return SequencePoint enumerated line
+        /// </summary>
+        /// <param name="LineNo"></param>
+        /// <returns></returns>
+        public string GetLine ( int LineNo ) {
+
+            string retString = String.Empty;
+
+            if ( LineNo > 0 && LineNo <= lines.Length ) {
+                lineInfo lineInfo = lines[LineNo-1];
+                retString = textSource.Substring(lineInfo.Offset, lineInfo.Length);
+            } else {
+                //Debug.Fail( "Line number out of range" );
+            }
+
+            return retString;
+        }
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="ToIndent"></param>
+        /// <param name="TabSize"></param>
+        /// <returns></returns>
+        public static string IndentTabs ( string ToIndent, int TabSize ) {
+            
+            string retString = ToIndent;
+            if ( ToIndent.Contains ( "\t" ) ) {
+                int counter = 0;
+                int remains = 0;
+                int repeat = 0;
+                char prevChar = char.MinValue;
+                var indented = new StringBuilder();
+                foreach ( char currChar in ToIndent ) {
+                    if ( currChar == '\t' ) {
+                        remains = counter % TabSize;
+                        repeat = remains == 0 ? TabSize : remains;
+                        indented.Append( ' ', repeat );
+                    } else {
+                        indented.Append ( currChar, 1 );
+                        if ( char.IsLowSurrogate(currChar) 
+                            && char.IsHighSurrogate(prevChar)
+                           ) { --counter; }
+                    }
+                    prevChar = currChar;
+                    ++counter;
+                }
+                retString = indented.ToString();
+            }
+            return retString;
+        }
+
+        /// <summary>
+        /// Get line-parsed source from file name
+        /// </summary>
+        /// <param name="filename"></param>
+        /// <returns></returns>
+		public static CodeCoverageStringTextSource GetSource(string filename) {
+
+			var retSource = (CodeCoverageStringTextSource)null;
+			try {
+				using (Stream stream = new FileStream(filename, FileMode.Open, FileAccess.Read)) {
+					try {
+						stream.Position = 0;
+						using (var reader = new StreamReader (stream, Encoding.Default, true)) {
+							retSource = new CodeCoverageStringTextSource(reader.ReadToEnd());
+						}
+					} catch (Exception) {}
+				}
+			} catch (Exception) {}
+
+			return retSource;
+		}
+
+    }
+}


### PR DESCRIPTION
I think, it will be difficult to detect all CGB (Compiler Generated Branches) without sources.
Only reliable way to select only UCB (User Code Branches) is to profile/instrument source code (not IL assembly). But, if we make connection to source we can at least improve.

So far, I detected some C# source-code-sequences of fixed length, always separated from other SequencePoints, that cannot contain UCB, but can contain CGB.
1) First bracket '{' on static method. Anyhow, no left or right bracket will ever contain UCB.
2) Enumerator keyword 'in' has CGB that can be reached only by enumerating over null IEnumerable, throwing an exception, which is usually prevented by null testing code or contract.

I would like to hear other people opinions and comments.