### PR TITLE
Sleep thread if yield fails

### DIFF
--- a/main/OpenCover.Framework/Manager/ProfilerManager.cs
+++ b/main/OpenCover.Framework/Manager/ProfilerManager.cs
@@ -151,7 +151,7 @@ namespace OpenCover.Framework.Manager
                 {
                     byte[] data;
                     while (!_messageQueue.TryDequeue(out data))
-                        Thread.Yield();
+                        ThreadHelper.YieldOrSleep(100);
 
                     _perfCounters.CurrentMemoryQueueSize = _messageQueue.Count;
                     _perfCounters.IncrementBlocksReceived();
@@ -289,7 +289,7 @@ namespace OpenCover.Framework.Manager
                             {
                                 do
                                 {
-                                    Thread.Yield();
+                                    ThreadHelper.YieldOrSleep(100);
                                 } while (_messageQueue.Count > 200);
                             }
                             break;

--- a/main/OpenCover.Framework/OpenCover.Framework.csproj
+++ b/main/OpenCover.Framework/OpenCover.Framework.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Utility\CodeCoverageStringTextSource.cs" />
     <Compile Include="Utility\IPerfCounters.cs" />
     <Compile Include="Utility\PerfCounters.cs" />
+    <Compile Include="Utility\ThreadHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="log4net.config">

--- a/main/OpenCover.Framework/Utility/ThreadHelper.cs
+++ b/main/OpenCover.Framework/Utility/ThreadHelper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace OpenCover.Framework.Utility
+{
+    internal static class ThreadHelper
+    {
+        public static void YieldOrSleep(int millisecondsInTimeout)
+        {
+            if (!Thread.Yield())
+            {
+                Thread.Sleep(millisecondsInTimeout);
+            }
+        }
+
+        public static void YieldOrSleep(TimeSpan timespan)
+        {
+            if (!Thread.Yield())
+            {
+                Thread.Sleep(timespan);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Yielding a thread may have [no affect at all](https://msdn.microsoft.com/en-us/library/system.threading.thread.yield(v=vs.110).aspx) (e.g. if there are no other threads to execute).

This PR introduces a helper method to sleep the current thread in case yield wasn't successful, i.e. it would still continue to run.

Supposed to fix #349.