### PR TITLE
Process is excluded if both assembly and class filters are specified

### DIFF
--- a/main/OpenCover.Framework/Filter.cs
+++ b/main/OpenCover.Framework/Filter.cs
@@ -336,7 +336,7 @@ namespace OpenCover.Framework
             }
 
             var matchingInclusionFilters = InclusionFilters.GetMatchingFiltersForProcessName(processName);
-            return matchingInclusionFilters.Any(inclusionFilter => inclusionFilter.AssemblyName == ".*" || inclusionFilter.ClassName == ".*");
+            return matchingInclusionFilters.Any();
         }
 
         /// <summary>

--- a/main/OpenCover.Test/Framework/FilterTests.cs
+++ b/main/OpenCover.Test/Framework/FilterTests.cs
@@ -803,6 +803,12 @@ namespace OpenCover.Test.Framework
         [TestCase("+{*}[*]*", "process.exe", true, true)]
         [TestCase("+{pro*}[*]*", "process.exe", true, true)]
         [TestCase("+{*cess}[*]*", "process.exe", true, true)]
+        [TestCase("+[ABC*]*", "nunit-executable.exe", true, true)]
+        [TestCase("+[*]DEF.*", "nunit-executable.exe", true, true)]
+        [TestCase("+[*]*", "process.exe", true, true)]
+        [TestCase("-[ABC*]*", "nunit-executable.exe", true, false)]
+        [TestCase("-[*]DEF.*", "nunit-executable.exe", true, false)]
+        [TestCase("-[*]*", "process.exe", true, false)]
         [TestCase("-{*}[*]* +{pro*}[*]*", "process.exe", true, false)]
         [TestCase("+{abc*}[*]* +{pro*}[*]*", "process.exe", true, true)]
         [TestCase("-{*}[ABC*]* +[*]*", "process.exe", true, true)]
@@ -829,7 +835,5 @@ namespace OpenCover.Test.Framework
             yield return string.Format("-filter:\"{0}\"", filterArg);
             if (!defaultFilters) yield return "-nodefaultfilters";
         }
-
-        
     }
 }

--- a/main/cmdline/dogfood_filter.cmd
+++ b/main/cmdline/dogfood_filter.cmd
@@ -1,0 +1,6 @@
+@echo off
+pushd %cd%
+cd %~dp0
+REM cover framework only
+OpenCover.Console.exe -register:user -target:..\..\..\main\packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe -targetargs:"OpenCover.Test.dll /noshadow /exclude:AdminOnly" -filter:"+[Open*]OpenCover.Framework* -[OpenCover.T*]* -{nunit-console*}[*]* -{pdb*}[*]*" -output:opencovertests-framework-filter.xml -communicationtimeout:9999
+popd


### PR DESCRIPTION
Using a filter of `+[assembly_name*]class_name*` would exclude all the processes, including the test runner, due to `Filter.InstrumentProcess` having:
``` csharp
var matchingInclusionFilters = InclusionFilters.GetMatchingFiltersForProcessName(processName);
return matchingInclusionFilters.Any(inclusionFilter => inclusionFilter.AssemblyName == ".*" || inclusionFilter.ClassName == ".*");
```

Supposed to fix #359.