### PR TITLE
Feature+ match process by path/name/extension, tests & bugfix

### DIFF
--- a/main/OpenCover.Framework/CommandLineParser.cs
+++ b/main/OpenCover.Framework/CommandLineParser.cs
@@ -283,7 +283,7 @@ namespace OpenCover.Framework
 
         private static List<string> ExtractFilters(string rawFilters)
         {
-            const string strRegex = @"([+-](\{.*?\})?[\[].*?[\]].+?\s)|([+-](\{.*\})?[\[].*?[\]].*)";
+            const string strRegex = @"([+-](\{.*?\})?[\[].*?[\]].+?\s)|([+-](\{.*\})?[\[].*?[\]][^\x22]*)";
             const RegexOptions myRegexOptions = RegexOptions.None;
             var myRegex = new Regex(strRegex, myRegexOptions);
             

--- a/main/OpenCover.Test/Framework/FilterTests.cs
+++ b/main/OpenCover.Test/Framework/FilterTests.cs
@@ -796,37 +796,80 @@ namespace OpenCover.Test.Framework
         }
 
         [Test]
-        [TestCase("+{*}[*]*", null, true, false)]
-        [TestCase("-{*}[*]*", "process.exe", true, false)]
-        [TestCase("-{pro*}[*]*", "process.exe", true, false)]
-        [TestCase("-{*cess}[*]*", "process.exe", true, false)]
+        [TestCase("+{*}[*]*", null, false, false)]
+        [TestCase("-{*}[*]*", "process.exe", false, false)]
+        [TestCase("-{pro*}[*]*", "process.exe", false, false)]
+        [TestCase("-{*cess}[*]*", "process.exe", false, false)]
         [TestCase("+{*}[*]*", "process.exe", true, true)]
         [TestCase("+{pro*}[*]*", "process.exe", true, true)]
         [TestCase("+{*cess}[*]*", "process.exe", true, true)]
         [TestCase("+[ABC*]*", "nunit-executable.exe", true, true)]
         [TestCase("+[*]DEF.*", "nunit-executable.exe", true, true)]
         [TestCase("+[*]*", "process.exe", true, true)]
-        [TestCase("-[ABC*]*", "nunit-executable.exe", true, false)]
-        [TestCase("-[*]DEF.*", "nunit-executable.exe", true, false)]
-        [TestCase("-[*]*", "process.exe", true, false)]
-        [TestCase("-{*}[*]* +{pro*}[*]*", "process.exe", true, false)]
+        [TestCase("-[ABC*]*", "nunit-executable.exe", true, true)] // not excluded when no default include filters, included with default include filter
+        [TestCase("-[*]DEF.*", "nunit-executable.exe", true, true)] // not excluded when no default include filters, included with default include filter
+        [TestCase("-[*]*", "process.exe", false, false)]
+        [TestCase("-{*}[*]* +{pro*}[*]*", "process.exe", false, false)]
         [TestCase("+{abc*}[*]* +{pro*}[*]*", "process.exe", true, true)]
         [TestCase("-{*}[ABC*]* +[*]*", "process.exe", true, true)]
-        [TestCase("-{*}[ABC*]* +{*}[*]*", "process.exe", false, true)]
-        [TestCase("-{pro*}[D*F]* +[*]*", "process.exe", false, true)]
-        [TestCase("-{*cess}[*GHI]* +[*]*", "process.exe", false, true)]
+        [TestCase("-{*}[ABC*]* +{*}[*]*", "process.exe", true, true)]
+        [TestCase("-{pro*}[D*F]* +[*]*", "process.exe", true, true)]
+        [TestCase("-{*cess}[*GHI]* +[*]*", "process.exe", true, true)]
         [TestCase("+{ABC}[*]*", "process.exe", false, false)]
-        [TestCase("+{pro*}[*]*", "process.exe", false, true)]
-        public void CanFilterByProcessName(string filterArg, string processName, bool defaultFilters, bool expected)
+        [TestCase("+{pro*}[*]*", "process.exe", true, true)]
+
+        // Instead of matching path, matches extracted "processName" same as above
+        [TestCase("-{pro*}[*]*", @"C:\Debug\process.exe", false, false)]
+        [TestCase("+{pro*}[*]*", @"C:\Debug\process.exe", true, true)]
+        [TestCase("-{*cess}[*]*", @"C:\Debug\process.exe", false, false)]
+        [TestCase("+{*cess}[*]*", @"C:\Debug\process.exe", true, true)]
+
+        [TestCase("-{pro*}[*]*", @"C:\Release\process.dll", false, false)]
+        [TestCase("+{pro*}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase("-{*cess}[*]*", @"C:\Release\process.dll", false, false)]
+        [TestCase("+{*cess}[*]*", @"C:\Release\process.dll", true, true)]
+
+        // Match only full name (path\name\ext)
+        [TestCase(@"-{C:\Debug\pro*}[*]*", @"C:\Debug\process.exe", false, false)]
+        [TestCase(@"+{C:\Debug\pro*}[*]*", @"C:\Debug\process.exe", true, true)]
+        [TestCase(@"-{*cess.exe}[*]*", @"C:\Debug\process.exe", false, false)]
+        [TestCase(@"+{*cess.exe}[*]*", @"C:\Debug\process.exe", true, true)]
+
+        // EXCLUDE MISMATCH test. 
+        // if not excluded and no include filters, then match
+        // if not excluded and include filters, then match include filtres
+        [TestCase(@"-{C:\Debug\pro*}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase(@"-{C:\Debug\pro*}[*]* +{C:\Release\*}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase(@"-{C:\Debug\pro*}[*]* +{process}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase(@"-{C:\Debug\pro*}[*]* +{noprocess}[*]*", @"C:\Release\process.dll", false, false)]
+
+        [TestCase(@"-{*cess.exe}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase(@"-{*cess.exe}[*]* +{process}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase(@"-{*cess.exe}[*]* +{process}[*]*", @"C:\Release\process.dll", true, true)]
+        [TestCase(@"-{*cess.exe}[*]* +{noprocess}[*]*", @"C:\Release\process.dll", false, false)]
+
+        [TestCase(@"+{C:\Debug\pro*}[*]*", @"C:\Release\process.dll", false, false)]
+        [TestCase(@"+{*cess.exe}[*]*", @"C:\Release\process.dll", false, false)]
+
+        public void CanFilterByProcessName(string filterArg, string processName, bool expectedNoDefaultFilters, bool expectedWithDefaultFilters)
         {
-            // arrange
-            var filter = Filter.BuildFilter(new CommandLineParser(GetFilter(filterArg, defaultFilters).ToArray()).Do(_ => _.ExtractAndValidateArguments()));
+            // arrange without default filters
+            var filter = Filter.BuildFilter(new CommandLineParser(GetFilter(filterArg, false).ToArray()).Do(_ => _.ExtractAndValidateArguments()));
 
             // act
             var instrument = filter.InstrumentProcess(processName);
 
             // assert
-            Assert.AreEqual(expected, instrument);
+            Assert.AreEqual(expectedNoDefaultFilters, instrument);
+
+            // arrange again with default filters
+            filter = Filter.BuildFilter(new CommandLineParser(GetFilter(filterArg, true).ToArray()).Do(_ => _.ExtractAndValidateArguments()));
+
+            // act
+            instrument = filter.InstrumentProcess(processName);
+
+            // assert
+            Assert.AreEqual(expectedWithDefaultFilters, instrument);
         }
 
         static IEnumerable<string> GetFilter(string filterArg, bool defaultFilters)


### PR DESCRIPTION
Match process by full name (drive:path\name.extension)
Matching process by file name (no path, no extension) is still available.