### PR TITLE
Relax parser for command line "-filter:.." option

### DIFF
--- a/main/OpenCover.Framework/CommandLineParser.cs
+++ b/main/OpenCover.Framework/CommandLineParser.cs
@@ -283,13 +283,13 @@ namespace OpenCover.Framework
 
         private static List<string> ExtractFilters(string rawFilters)
         {
-            // always starts wih +-
-            // followed by optional "<filter-expr>" process-filter, where optional "filter-expr" excludes "<>" 
-            // followed by required "[filter-expr]" assembly-filter, where optional "filter-expr" excludes "[]" 
-            // followed by optional "filter-expr" class-filter, where optional "filter-expr" excludes +,-,space,doublequote
+            // starts with required +-
+            // followed by optional process-filter
+            // followed by required assembly-filter 
+            // followed by optional class-filter, where class-filter excludes -+" and space characters
             // followed by optional space 
-            // NOTE: double-quote character from test-values somehow sneaks into filter as last character?
-            const string strRegex = @"[-\+](<[^<>]*>)?\[[^\[\]]*\][^-\+\s\x22]*\s*";
+            // NOTE: double-quote character from test-values somehow sneaks into default filter as last character?
+            const string strRegex = @"[\-\+](<.*?>)?(\[.*?\])[^\-\+\s\x22]*\s*";
             const RegexOptions myRegexOptions = RegexOptions.Singleline | RegexOptions.ExplicitCapture;
             var myRegex = new Regex(strRegex, myRegexOptions);
             

--- a/main/OpenCover.Framework/Filter.cs
+++ b/main/OpenCover.Framework/Filter.cs
@@ -140,7 +140,7 @@ namespace OpenCover.Framework
 
             if (!RegExFilters)
             {
-                processName = (string.IsNullOrEmpty(processName) ? "*" : processName).ValidateAndEscape("/?\"<>|}{");
+                processName = (string.IsNullOrEmpty(processName) ? "*" : processName).ValidateAndEscape("<>|\""); // invalid dir\filename characters 
                 assemblyName = assemblyName.ValidateAndEscape();
                 className = className.ValidateAndEscape();
             }


### PR DESCRIPTION
For regex-expression filters, parser should accept any character
sequence between < > and between [ ].