### PR TITLE
Use VS2015 for builds in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 4.6.{build}
 skip_tags: true
-os: Unstable
+os: Visual Studio 2015
 shallow_clone: true
 environment:
   COVERALLS_REPO_TOKEN:


### PR DESCRIPTION
Originally (#252) the Unstable version was used because of VS2013 CE availability, by now VS 2015 is also available.