### PR TITLE
Remove compiler generated branches ++

### DIFF
--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -741,7 +741,7 @@ namespace OpenCover.Framework.Persistance
                             sp.BranchExitsVisit += branchPoint.VisitCount == 0 ? 0 : 1;
                         }
                         // Add to validBranchPoints
-                        validBranchPoints.AddRange(branchExits.Values.ToList());
+                        validBranchPoints.AddRange(sp.BranchPoints);
                         sp.BranchPoints = new List<BranchPoint>();
                     }
                 }

--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -707,7 +707,8 @@ namespace OpenCover.Framework.Persistance
         }
 
         /// <summary>
-        /// Reduces number of CIL branches to real number by finding common exit offset (switch/case)
+        /// Computes reduced SequencePoint branch coverage  
+        /// by finding common exit offset (switch/case)
         /// </summary>
         /// <param name="methods"></param>
         private static void TransformSequences_ReduceBranches (IEnumerable<Method> methods)

--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -547,9 +547,9 @@ namespace OpenCover.Framework.Persistance
                     TransformSequences_Initialize (methods);
                     TransformSequences_JoinWithBranches (methods);
                     TransformSequences_AddSources (module.Files, methods, sourceRepository);
-                    TransformSequences_RemoveBranchesOutOfOffset  (methods, sourceRepository);
+                    TransformSequences_RemoveCompilerGeneratedBranches  (methods, sourceRepository);
                     TransformSequences_RemoveFalsePositiveUnvisited (methods, sourceRepository);
-                    TransformSequences_NormalizeBranches (methods); // last
+                    TransformSequences_ReduceBranches (methods); // last
                 }
             }
         }
@@ -626,7 +626,7 @@ namespace OpenCover.Framework.Persistance
             }
         }
 
-        private static void TransformSequences_RemoveBranchesOutOfOffset (IEnumerable<Method> methods, SourceRepository sourceRepository)
+        private static void TransformSequences_RemoveCompilerGeneratedBranches (IEnumerable<Method> methods, SourceRepository sourceRepository)
         {
             foreach (var method in methods) {
             
@@ -644,7 +644,7 @@ namespace OpenCover.Framework.Persistance
                 CodeCoverageStringTextSource source = sourceRepository.getCodeCoverageStringTextSource(method.FileRef.UniqueId);
                 if (source != null && source.FileType == FileType.CSharp && !method.IsGenerated) {
 
-                    #region Use Offset To Remove Compiler Generated Branches
+                    #region Use Offset and source To Remove Compiler Generated Branches
 
                     if (method.SequencePoints != null && method.SequencePoints.Length != 0) {
                         
@@ -693,6 +693,8 @@ namespace OpenCover.Framework.Persistance
                                     else if (trimmed.StartsWith ("Contract.Ensures", StringComparison.Ordinal) ) {
                                         sp.BranchPoints = new List<BranchPoint>();
                                     }
+                                } else if (trimmed == "in") {
+                                    sp.BranchPoints = new List<BranchPoint>();
                                 }
                             }
                         }
@@ -704,7 +706,11 @@ namespace OpenCover.Framework.Persistance
             }
         }
 
-        private static void TransformSequences_NormalizeBranches (IEnumerable<Method> methods)
+        /// <summary>
+        /// Reduces number of CIL branches to real number by finding common exit offset (switch/case)
+        /// </summary>
+        /// <param name="methods"></param>
+        private static void TransformSequences_ReduceBranches (IEnumerable<Method> methods)
         {
             foreach (var method in methods) {
 
@@ -735,7 +741,7 @@ namespace OpenCover.Framework.Persistance
                             sp.BranchExitsVisit += branchPoint.VisitCount == 0 ? 0 : 1;
                         }
                         // Add to validBranchPoints
-                        validBranchPoints.AddRange(sp.BranchPoints);
+                        validBranchPoints.AddRange(branchExits.Values.ToList());
                         sp.BranchPoints = new List<BranchPoint>();
                     }
                 }


### PR DESCRIPTION
1) Remove branches from 'in' keyword (https://github.com/OpenCover/opencover/issues/420)
~~2) Reduce list of reported branches merged by exit-offset to match sequence point bec&bev counter-attributes~~