### PR TITLE
#521 remove path-matching

### DIFF
--- a/main/OpenCover.Framework/Communication/MessageHandler.cs
+++ b/main/OpenCover.Framework/Communication/MessageHandler.cs
@@ -313,7 +313,7 @@ namespace OpenCover.Framework.Communication
             try
             {
                 var request = _marshalWrapper.PtrToStructure<MSG_TrackProcess_Request>(pinnedMemory);
-                response.track = _profilerCommunication.TrackProcess(request.processName);
+                response.track = _profilerCommunication.TrackProcess(request.processPath);
             }
             catch (Exception ex)
             {

--- a/main/OpenCover.Framework/Communication/Messages.cs
+++ b/main/OpenCover.Framework/Communication/Messages.cs
@@ -400,7 +400,7 @@ namespace OpenCover.Framework.Communication
         /// The path to the process
         /// </summary>
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 512)]
-        public string processName;
+        public string processPath;
     }
 
     /// <summary>

--- a/main/OpenCover.Framework/Filtering/AssemblyAndClassFilter.cs
+++ b/main/OpenCover.Framework/Filtering/AssemblyAndClassFilter.cs
@@ -26,14 +26,14 @@ namespace OpenCover.Framework.Filtering
             _classFilter = new RegexFilter(classFilter);
         }
 
-        internal bool IsMatchingProcessName(string processPathOrName)
+        internal bool IsMatchingProcessName(string processName)
         {
-            return _processFilter.IsMatchingExpression(processPathOrName);
+            return _processFilter.IsMatchingExpression(processName);
         }
 
-        internal bool IsMatchingAssemblyName(string assemblyPathOrName)
+        internal bool IsMatchingAssemblyName(string assemblyName)
         {
-            return _assemblyFilter.IsMatchingExpression(assemblyPathOrName);
+            return _assemblyFilter.IsMatchingExpression(assemblyName);
         }
 
         internal bool IsMatchingClassName(string className)

--- a/main/OpenCover.Framework/IFilter.cs
+++ b/main/OpenCover.Framework/IFilter.cs
@@ -18,11 +18,11 @@ namespace OpenCover.Framework
         /// <summary>
         /// Decides whether an assembly should be included in the instrumentation
         /// </summary>
-        /// <param name="processPath">The name of the process being profiled</param>
-        /// <param name="assemblyPath">the name of the assembly under profile</param>
+        /// <param name="processName">The name of the process being profiled</param>
+        /// <param name="assemblyName">the name of the assembly under profile</param>
         /// <remarks>All assemblies matching either the inclusion or exclusion filter should be included 
         /// as it is the class that is being filtered within these unless the class filter is *</remarks>
-        bool UseAssembly(string processPath, string assemblyPath);
+        bool UseAssembly(string processName, string assemblyName);
 
         /// <summary>
         /// Decides whether an assembly should be analysed for test methods
@@ -40,19 +40,19 @@ namespace OpenCover.Framework
         /// <summary>
         /// Determine if an [assemblyname]classname pair matches the current Exclusion or Inclusion filters  
         /// </summary>
-        /// <param name="assemblyPath">the name of the assembly under profile</param>
+        /// <param name="assemblyName">the name of the assembly under profile</param>
         /// <param name="className">the name of the class under profile</param>
         /// <returns>false - if pair matches the exclusion filter or matches no filters, true - if pair matches in the inclusion filter</returns>
-        bool InstrumentClass(string assemblyPath, string className);
+        bool InstrumentClass(string assemblyName, string className);
 
         /// <summary>
         /// Determine if an [assemblyname]classname pair matches the current Exclusion or Inclusion filters  
         /// </summary>
-        /// <param name="processPath">The path-name of the process</param>
-        /// <param name="assemblyPath">The path-name of the assembly under profile</param>
+        /// <param name="processName">The name of the process</param>
+        /// <param name="assemblyName">The name of the assembly under profile</param>
         /// <param name="className">the name of the class under profile</param>
         /// <returns>false - if pair matches the exclusion filter or matches no filters, true - if pair matches in the inclusion filter</returns>
-        bool InstrumentClass(string processPath, string assemblyPath, string className);
+        bool InstrumentClass(string processName, string assemblyName, string className);
 
 
         /// <summary>
@@ -103,9 +103,9 @@ namespace OpenCover.Framework
         /// <summary>
         /// Should we instrument this process
         /// </summary>
-        /// <param name="processPath"></param>
+        /// <param name="processName"></param>
         /// <returns></returns>
-        bool InstrumentProcess(string processPath);
+        bool InstrumentProcess(string processName);
     }
 
 }

--- a/main/OpenCover.Framework/Service/IProfilerCommunication.cs
+++ b/main/OpenCover.Framework/Service/IProfilerCommunication.cs
@@ -16,33 +16,33 @@ namespace OpenCover.Framework.Service
         /// <summary>
         /// Should we track this assembly
         /// </summary>
-        /// <param name="processName"></param>
+        /// <param name="processPath"></param>
         /// <param name="modulePath"></param>
         /// <param name="assemblyName"></param>
         /// <returns></returns>
-        bool TrackAssembly(string processName, string modulePath, string assemblyName);
+        bool TrackAssembly(string processPath, string modulePath, string assemblyName);
 
         /// <summary>
         /// Get sequence points
         /// </summary>
-        /// <param name="processName"></param>
+        /// <param name="processPath"></param>
         /// <param name="modulePath"></param>
         /// <param name="assemblyName"></param>
         /// <param name="functionToken"></param>
         /// <param name="sequencePoints"></param>
         /// <returns></returns>
-        bool GetSequencePoints(string processName, string modulePath, string assemblyName, int functionToken, out InstrumentationPoint[] sequencePoints);
+        bool GetSequencePoints(string processPath, string modulePath, string assemblyName, int functionToken, out InstrumentationPoint[] sequencePoints);
 
         /// <summary>
         /// Get branch points
         /// </summary>
-        /// <param name="processName"></param>
+        /// <param name="processPath"></param>
         /// <param name="modulePath"></param>
         /// <param name="assemblyName"></param>
         /// <param name="functionToken"></param>
         /// <param name="branchPoints"></param>
         /// <returns></returns>
-        bool GetBranchPoints(string processName, string modulePath, string assemblyName, int functionToken, out BranchPoint[] branchPoints);
+        bool GetBranchPoints(string processPath, string modulePath, string assemblyName, int functionToken, out BranchPoint[] branchPoints);
 
         /// <summary>
         /// We are stopping...
@@ -62,8 +62,8 @@ namespace OpenCover.Framework.Service
         /// <summary>
         /// Should we track this process
         /// </summary>
-        /// <param name="processName"></param>
+        /// <param name="processPath"></param>
         /// <returns></returns>
-        bool TrackProcess(string processName);
+        bool TrackProcess(string processPath);
     }
 }

--- a/main/OpenCover.Framework/Service/ProfilerCommunication.cs
+++ b/main/OpenCover.Framework/Service/ProfilerCommunication.cs
@@ -33,7 +33,7 @@ namespace OpenCover.Framework.Service
             Module module = null;
             var builder = _instrumentationModelBuilderFactory.CreateModelBuilder(modulePath, assemblyName);
 
-            if (!_filter.UseAssembly(processPath, assemblyName))
+            if (!_filter.UseAssembly(Path.GetFileNameWithoutExtension (processPath), assemblyName))
             {
                 module = builder.BuildModuleModel(false);
                 module.MarkAsSkipped(SkippedMethod.Filter);
@@ -59,38 +59,38 @@ namespace OpenCover.Framework.Service
             return !module.ShouldSerializeSkippedDueTo();
         }
 
-        public bool GetBranchPoints(string processName, string modulePath, string assemblyName, int functionToken, out BranchPoint[] instrumentPoints)
+        public bool GetBranchPoints(string processPath, string modulePath, string assemblyName, int functionToken, out BranchPoint[] instrumentPoints)
         {
             BranchPoint[] points = null;
 
             var ret = GetPoints(() => _persistance.GetBranchPointsForFunction(modulePath, functionToken, out points),
-                    processName, modulePath, assemblyName, functionToken, out instrumentPoints);
+                    processPath, modulePath, assemblyName, functionToken, out instrumentPoints);
 
             instrumentPoints = points;
             return ret;
         }
 
-        public bool GetSequencePoints(string processName, string modulePath, string assemblyName, int functionToken, out InstrumentationPoint[] instrumentPoints)
+        public bool GetSequencePoints(string processPath, string modulePath, string assemblyName, int functionToken, out InstrumentationPoint[] instrumentPoints)
         {
             InstrumentationPoint[] points = null;
 
             var ret = GetPoints(() => _persistance.GetSequencePointsForFunction(modulePath, functionToken, out points),
-                                processName, modulePath, assemblyName, functionToken, out instrumentPoints);
+                                processPath, modulePath, assemblyName, functionToken, out instrumentPoints);
 
             instrumentPoints = points;
             return ret;
         }
 
-        private bool GetPoints<T>(Func<bool> getPointsFunc, string processName, string modulePath, string assemblyName, int functionToken, out T[] points)
+        private bool GetPoints<T>(Func<bool> getPointsFunc, string processPath, string modulePath, string assemblyName, int functionToken, out T[] points)
         {
             points = new T[0];
-            return CanReturnPoints(processName, modulePath, assemblyName, functionToken) && getPointsFunc();
+            return CanReturnPoints(processPath, modulePath, assemblyName, functionToken) && getPointsFunc();
         }
 
-        private bool CanReturnPoints(string processName, string modulePath, string assemblyName, int functionToken)
+        private bool CanReturnPoints(string processPath, string modulePath, string assemblyName, int functionToken)
         {
             var className = _persistance.GetClassFullName(modulePath, functionToken);
-            return _filter.InstrumentClass(processName, assemblyName, className);
+            return _filter.InstrumentClass(Path.GetFileNameWithoutExtension (processPath), assemblyName, className);
         }
 
         public void Stopping()
@@ -103,9 +103,9 @@ namespace OpenCover.Framework.Service
             return _persistance.GetTrackingMethod(modulePath, assemblyName,functionToken, out uniqueId);
         }
 
-        public bool TrackProcess(string processName)
+        public bool TrackProcess(string processPath)
         {
-            return _filter.InstrumentProcess(processName);
+            return _filter.InstrumentProcess(Path.GetFileNameWithoutExtension (processPath));
         }
     }
 }

--- a/main/OpenCover.Framework/Symbols/CecilSymbolManager.cs
+++ b/main/OpenCover.Framework/Symbols/CecilSymbolManager.cs
@@ -175,15 +175,11 @@ namespace OpenCover.Framework.Symbols
             var classes = new List<Class>();
             IEnumerable<TypeDefinition> typeDefinitions = SourceAssembly.MainModule.Types;
 
-            var assemblyPath = ModuleName;
-            if (ModulePath.Contains(assemblyPath))
-                assemblyPath = ModulePath;
-
-            GetInstrumentableTypes(typeDefinitions, classes, _filter, assemblyPath);
+            GetInstrumentableTypes(typeDefinitions, classes, _filter, ModuleName);
             return classes.ToArray();
         }
 
-        private static void GetInstrumentableTypes(IEnumerable<TypeDefinition> typeDefinitions, List<Class> classes, IFilter filter, string assemblyPath)
+        private static void GetInstrumentableTypes(IEnumerable<TypeDefinition> typeDefinitions, List<Class> classes, IFilter filter, string assemblyName)
         {
             foreach (var typeDefinition in typeDefinitions)
             {
@@ -192,21 +188,21 @@ namespace OpenCover.Framework.Symbols
                 if (typeDefinition.IsInterface && typeDefinition.IsAbstract) 
                     continue;
 
-                var @class = BuildClass(filter, assemblyPath, typeDefinition);
+                var @class = BuildClass(filter, assemblyName, typeDefinition);
 
                 // only instrument types that are not structs and have instrumentable points
                 if (!typeDefinition.IsValueType || @class.Files.Maybe(f => f.Length) > 0)
                     classes.Add(@class);
 
                 if (typeDefinition.HasNestedTypes) 
-                    GetInstrumentableTypes(typeDefinition.NestedTypes, classes, filter, assemblyPath); 
+                    GetInstrumentableTypes(typeDefinition.NestedTypes, classes, filter, assemblyName); 
             }                                                                                        
         }
 
-        private static Class BuildClass(IFilter filter, string assemblyPath, TypeDefinition typeDefinition)
+        private static Class BuildClass(IFilter filter, string assemblyName, TypeDefinition typeDefinition)
         {
             var @class = new Class {FullName = typeDefinition.FullName};
-            if (!filter.InstrumentClass(assemblyPath, @class.FullName))
+            if (!filter.InstrumentClass(assemblyName, @class.FullName))
             {
                 @class.MarkAsSkipped(SkippedMethod.Filter);
             }

--- a/main/OpenCover.Test/Framework/FilterTests.cs
+++ b/main/OpenCover.Test/Framework/FilterTests.cs
@@ -207,7 +207,7 @@ namespace OpenCover.Test.Framework
             data.Filters.ForEach(filter.AddFilter);
 
             // act
-            var result = filter.UseAssembly("processName.exe", data.Assembly);
+            var result = filter.UseAssembly("processName", data.Assembly);
 
             // result
             Assert.AreEqual(data.ExpectedResult, result,
@@ -732,7 +732,7 @@ namespace OpenCover.Test.Framework
             // act
 
             // assert
-            Assert.AreEqual(canUse, filter.UseAssembly("processName.exe", assembly));
+            Assert.AreEqual(canUse, filter.UseAssembly("processName", assembly));
         }
 
         [Test]
@@ -791,7 +791,7 @@ namespace OpenCover.Test.Framework
         {
             var filter = Filter.BuildFilter(new CommandLineParser(commandLine).Do(_ => _.ExtractAndValidateArguments()));
             Assert.IsNotNull(filter);
-            Assert.AreEqual(matchAssembly, filter.UseAssembly("processName.exe", "System"));
+            Assert.AreEqual(matchAssembly, filter.UseAssembly("processName", "System"));
         }
 
         [Test]
@@ -801,86 +801,71 @@ namespace OpenCover.Test.Framework
 
         #region Initial test set
         [TestCase("+<*>[*]*", null, false, false)]
-        [TestCase("-<*>[*]*", "process.exe", false, false)]
-        [TestCase("-<pro*>[*]*", "process.exe", false, false)]
-        [TestCase("-<*cess>[*]*", "process.exe", false, false)]
-        [TestCase("+<*>[*]*", "process.exe", true, true)]
-        [TestCase("+<pro*>[*]*", "process.exe", true, true)]
-        [TestCase("+<*cess>[*]*", "process.exe", true, true)]
-        [TestCase("+[ABC*]*", "nunit-executable.exe", true, true)]
-        [TestCase("+[*]DEF.*", "nunit-executable.exe", true, true)]
-        [TestCase("+[*]*", "process.exe", true, true)]
-        [TestCase("-[ABC*]*", "nunit-executable.exe", true, true)]
-        [TestCase("-[*]DEF.*", "nunit-executable.exe", true, true)]
-        [TestCase("-[*]*", "process.exe", false, false)]
-        [TestCase("-<*>[*]* +<pro*>[*]*", "process.exe", false, false)]
-        [TestCase("+<abc*>[*]* +<pro*>[*]*", "process.exe", true, true)]
-        [TestCase("-<*>[ABC*]* +[*]*", "process.exe", true, true)]
-        [TestCase("-<*>[ABC*]* +<*>[*]*", "process.exe", true, true)]
-        [TestCase("-<pro*>[D*F]* +[*]*", "process.exe", true, true)]
-        [TestCase("-<*cess>[*GHI]* +[*]*", "process.exe", true, true)]
-        [TestCase("+<ABC>[*]*", "process.exe", false, false)]
-        [TestCase("+<pro*>[*]*", "process.exe", true, true)]
-        #endregion
-
-        #region match no drive-path-extension, only process-name (same as above)
-        [TestCase("-<pro*>[*]*", @"C:\Debug\process.exe", false, false)]
-        [TestCase("+<pro*>[*]*", @"C:\Debug\process.exe", true, true)]
-        [TestCase("-<*cess>[*]*", @"C:\Debug\process.exe", false, false)]
-        [TestCase("+<*cess>[*]*", @"C:\Debug\process.exe", true, true)]
-        #endregion
-
-        #region match full-path-process-name (path\name\ext)
-        [TestCase(@"-<C:\Debug\pro*>[*]*", @"C:\Debug\process.exe", false, false)]
-        [TestCase(@"+<C:\Debug\pro*>[*]*", @"C:\Debug\process.exe", true, true)]
-
-        [TestCase(@"-<*cess.exe>[*]*", @"C:\Debug\process.exe", false, false)]
-        [TestCase(@"-<*cess.dll>[*]*", @"C:\Debug\process.exe", true, true)]
-
-        [TestCase(@"+<*cess.dll>[*]*", @"C:\Debug\process.exe", false, false)]
-        [TestCase(@"+<*cess.exe>[*]*", @"C:\Debug\process.exe", true, true)]
+        [TestCase("-<*>[*]*", "process", false, false)]
+        [TestCase("-<pro*>[*]*", "process", false, false)]
+        [TestCase("-<*cess>[*]*", "process", false, false)]
+        [TestCase("+<*>[*]*", "process", true, true)]
+        [TestCase("+<pro*>[*]*", "process", true, true)]
+        [TestCase("+<*cess>[*]*", "process", true, true)]
+        [TestCase("+[ABC*]*", "nunit-executable", true, true)]
+        [TestCase("+[*]DEF.*", "nunit-executable", true, true)]
+        [TestCase("+[*]*", "process", true, true)]
+        [TestCase("-[ABC*]*", "nunit-executable", true, true)]
+        [TestCase("-[*]DEF.*", "nunit-executable", true, true)]
+        [TestCase("-[*]*", "process", false, false)]
+        [TestCase("-<*>[*]* +<pro*>[*]*", "process", false, false)]
+        [TestCase("+<abc*>[*]* +<pro*>[*]*", "process", true, true)]
+        [TestCase("-<*>[ABC*]* +[*]*", "process", true, true)]
+        [TestCase("-<*>[ABC*]* +<*>[*]*", "process", true, true)]
+        [TestCase("-<pro*>[D*F]* +[*]*", "process", true, true)]
+        [TestCase("-<*cess>[*GHI]* +[*]*", "process", true, true)]
+        [TestCase("+<ABC>[*]*", "process", false, false)]
+        [TestCase("+<pro*>[*]*", "process", true, true)]
         #endregion
 
         #region match when both filters, when no exclude filters, or when no include filters or when no filters at all
+
         // 1/1 match include filter if not excluded
-        [TestCase(@"-<C:\Debug\pro*>[*]* +<noprocess>[*]*", @"C:\Release\process.exe", false, false)]
-        [TestCase(@"-<C:\Debug\pro*>[*]* +<process>[*]*", @"C:\Release\process.exe", true, true)]
+        [TestCase(@"-<pro*>[*]* +<no-process>[*]*", "noprocess", false, false)]
+        [TestCase(@"-<pro*>[*]* +<noprocess>[*]*", "noprocess", true, true)]
 
         // 1/0 include if not excluded and no include filters
-        [TestCase(@"-<C:\Debug\pro*>[*]*", @"C:\Release\process.exe", true, true)]
+        [TestCase(@"-<pro*>[*]*", "noprocess", true, true)]
 
         // 0/1 match include filter if no exclude filters exists
-        [TestCase(@"+<C:\Debug\pro*>[*]*", @"C:\Release\process.exe", false, false)]
-        [TestCase(@"+<C:\Debug\pro*>[*]*", @"C:\Debug\process.exe", true, true)]
+        [TestCase(@"+<pro*>[*]*", "noprocess", false, false)]
+        [TestCase(@"+<pro*>[*]*", "process", true, true)]
         
         // 0/0 always include if no exclude and no include filters
         [TestCase(@"", @"C:\Release\process.exe", true, true)]
+
         #endregion
 
         #region exclude only when filter does not ends with [*]*
-        [TestCase(@"-<*>[*]*", @"C:\Debug\process.exe", false, false)]
-        [TestCase(@"-<*>[*x*]*", @"C:\Debug\process.exe", true, true)]
-        [TestCase(@"-<*>[*]*x*", @"C:\Debug\process.exe", true, true)]
-        [TestCase(@"-<*>[*x*]*x*", @"C:\Debug\process.exe", true, true)]
+
+        [TestCase(@"-<*>[*]*", "process", false, false)]
+        [TestCase(@"-<*>[*x*]*", "process", true, true)]
+        [TestCase(@"-<*>[*]*x*", "process", true, true)]
+        [TestCase(@"-<*>[*x*]*x*", "process", true, true)]
+
         #endregion
 
         #region always include matching process regardless how process filter ends ([*]*|[*x*]*x*)
-        [TestCase(@"+<*>[*]*", @"C:\Debug\process.exe", true, true)]
-        [TestCase(@"+<*>[*x*]*", @"C:\Debug\process.exe", true, true)]
-        [TestCase(@"+<*>[*]*x*", @"C:\Debug\process.exe", true, true)]
-        [TestCase(@"+<*>[*x*]*x*", @"C:\Debug\process.exe", true, true)]
+
+        [TestCase(@"+<*>[*]*", "process", true, true)]
+        [TestCase(@"+<*>[*x*]*", "process", true, true)]
+        [TestCase(@"+<*>[*]*x*", "process", true, true)]
+        [TestCase(@"+<*>[*x*]*x*", "process", true, true)]
+
         #endregion
 
         #region never exclude proces that matches default-assembly-exclusion-filters (ie "mscorlib" when exclusion filters enabled)
-        [TestCase(@"-<C:\Debug\pro*>[*]*", @"C:\dotNet\mscorlib.dll", true, true)]
+
+        [TestCase(@"-<pro*>[*]*", @"C:\dotNet\mscorlib.dll", true, true)]
 
         // issue found by user #329
-        [TestCase(@"+[Open*]* -[OpenCover.T*]* -[*nunit*]*", @"C:\Release\nunit-console.exe.exe", true, true)]
+        [TestCase(@"+[Open*]* -[OpenCover.T*]* -[*nunit*]*", "nunit-console", true, true)]
 
-        #endregion
-
-        #region Cover last branches with invalid path chars (Path.GetInvalidPathChars)
-        [TestCase(@"+<*>[*]*", "C:\\Debug\\process.exe|<>\"", true, true)]
         #endregion
 
         public void CanFilterByProcessName(string filterArg, string processName, bool expectedNoDefaultFilters, bool expectedWithDefaultFilters)


### PR DESCRIPTION
process string is named processPath in
Messages.cs
MessageHandler
IProfilerCommunication.cs

and ProfilerCommunication.cs where is transformed to processName by call
to Path.GetFileNameWithoutExtension (processPath) when calling
UseAssembly, InstrumentClass and InstrumentProcess

It is processName in
IFilter.cs, Filter.cs and AssemblyAndClassFilter.cs