### PR TITLE
set RedirectStandardOutput to true

### DIFF
--- a/main/OpenCover.Specs/Steps/PackagingSteps.cs
+++ b/main/OpenCover.Specs/Steps/PackagingSteps.cs
@@ -155,7 +155,8 @@ namespace OpenCover.Specs.Steps
             var startInfo = new ProcessStartInfo(openCover)
             {
                 Arguments = string.Format(@"-register:user ""-target:{0}"" ""-output:{1}""", target, outputXml),
-                UseShellExecute = false
+                UseShellExecute = false,
+                RedirectStandardOutput = true
             };
             var process = Process.Start(startInfo);
             Assert.NotNull(process);


### PR DESCRIPTION
due to change in nunit console runner the output of these executions is now being captured in the build log and it is not necessary nor valuable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/596)
<!-- Reviewable:end -->
