### PR TITLE
Can now use the MSBuild task when deploying OpenCover with NuGet

### DIFF
--- a/main/OpenCover.MSBuild/OpenCover.cs
+++ b/main/OpenCover.MSBuild/OpenCover.cs
@@ -1,17 +1,9 @@
 ﻿//
 // This source code is released under the MIT License; see the accompanying license file.
 //
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.RegularExpressions;
+using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Win32;
@@ -51,39 +43,42 @@ namespace OpenCover.MSBuild
         /// <returns>The full path to the OpenCover tool.</returns>
         protected override string GenerateFullPathToTool()
         {
-            string path=ToolPath;
             string exe=Path.GetFileName(ToolExe);
 
-            if (string.IsNullOrEmpty(path)) {
-                if (File.Exists(exe))
-                    return Path.GetFullPath(exe);
+            if (!string.IsNullOrEmpty(ToolPath))
+                return Path.GetFullPath(Path.Combine(ToolPath, exe));
 
-                RegistryKey key=null;
+            // NuGet deployment
+            var path = Path.Combine(Path.GetDirectoryName(Assembly.GetAssembly(typeof(OpenCover)).Location), "..\\tools", exe);
+            if (File.Exists(path))
+                return Path.GetFullPath(path);
 
-                string[] keyNames=new string[] { _OpenCoverRegKey, _OpenCoverRegKeyWow6432 };
-                foreach (string kn in keyNames)
-                {
-                    key=Registry.CurrentUser.OpenSubKey(kn);
-                    if (key!=null)
-                        break;
+            // OpenCover has been installed
+            RegistryKey key=null;
 
-                    key=Registry.LocalMachine.OpenSubKey(kn);
-                    if (key!=null)
-                        break;
-                }
+            string[] keyNames=new string[] { _OpenCoverRegKey, _OpenCoverRegKeyWow6432 };
+            foreach (string kn in keyNames)
+            {
+                key=Registry.CurrentUser.OpenSubKey(kn);
+                if (key!=null)
+                    break;
 
-                if (key==null)
-                {
-                    Log.LogError("Could not find OpenCover installation registry key. Please install OpenCover or repair installation.");
-                    return null;
-                }
+                key=Registry.LocalMachine.OpenSubKey(kn);
+                if (key!=null)
+                    break;
+            }
 
-                path=(string)key.GetValue(_OpenCoverRegValue);
-                if (string.IsNullOrEmpty(path))
-                {
-                    Log.LogError("Could not find OpenCover installation path. Please repair OpenCover installation.");
-                    return null;
-                }
+            if (key==null)
+            {
+                Log.LogError("Could not find OpenCover installation registry key. Please install OpenCover or repair installation.");
+                return null;
+            }
+
+            path=(string)key.GetValue(_OpenCoverRegValue);
+            if (string.IsNullOrEmpty(path))
+            {
+                Log.LogError("Could not find OpenCover installation path. Please repair OpenCover installation.");
+                return null;
             }
 
             return Path.GetFullPath(Path.Combine(path, exe));
@@ -108,9 +103,7 @@ namespace OpenCover.MSBuild
             if (ShowUnvisited)
                 builder.AppendSwitch("-showunvisited");
             if (ReturnTargetCode)
-            {
-                builder.AppendSwitch("-returntargetcode" + (TargetCodeOffset != 0 ? string.Format(":{0}", TargetCodeOffset) : null));
-            }
+                builder.AppendSwitch("-returntargetcode" + (TargetCodeOffset != 0 ? string.Format(CultureInfo.InvariantCulture, ":{0}", TargetCodeOffset) : null));
 
             builder.AppendSwitchIfNotNull("-target:", Target);
             builder.AppendSwitchIfNotNull("-targetdir:", TargetWorkingDir);

--- a/main/OpenCover.MSBuild/OpenCover.targets
+++ b/main/OpenCover.MSBuild/OpenCover.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <OpenCoverMSBuildTasksPath Condition="'$(OpenCoverMSBuildTasksPath)' == ''">$(MSBuildExtensionsPath32)\OpenCover</OpenCoverMSBuildTasksPath>
+    <OpenCoverMSBuildTasksPath Condition="'$(OpenCoverMSBuildTasksPath)' == ''">$(MSBuildThisFileDirectory)</OpenCoverMSBuildTasksPath>
     <OpenCoverMSBuildTasksLib>$(OpenCoverMSBuildTasksPath)\OpenCover.MSBuild.dll</OpenCoverMSBuildTasksLib>
   </PropertyGroup>
 


### PR DESCRIPTION
Please provide the following information when submitting an pull request, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

- #617

### Details on the issue fix or feature implementation

If no `ToolPath` is provided, we try to find OpenCover:
- next to the current directory (`..\tools\`, NuGet deployment).
- in the registry, as was the case before.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or which ever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 


