### PR TITLE
Added support for Xunit.TheoryAttribute and NUnit.Framework.TestCaseSourceAttribute

### DIFF
--- a/main/OpenCover.Extensions/Strategy/TrackNUnitTestMethods.cs
+++ b/main/OpenCover.Extensions/Strategy/TrackNUnitTestMethods.cs
@@ -13,7 +13,8 @@ namespace OpenCover.Extensions.Strategy
         {
             "NUnit.Framework.TestAttribute",
             "NUnit.Framework.TestCaseAttribute",
-            "NUnit.Framework.TheoryAttribute"
+            "NUnit.Framework.TheoryAttribute",
+            "NUnit.Framework.TestCaseSourceAttribute"
         };
 
         public TrackNUnitTestMethods() : base(NUnitStrategyName, TrackedAttributeTypeNames)

--- a/main/OpenCover.Extensions/Strategy/TrackXUnitTestMethods.cs
+++ b/main/OpenCover.Extensions/Strategy/TrackXUnitTestMethods.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace OpenCover.Extensions.Strategy
 {
     /// <summary>
@@ -5,7 +7,15 @@ namespace OpenCover.Extensions.Strategy
     /// </summary>
     public class TrackXUnitTestMethods : TrackedMethodStrategyBase
     {
-        public TrackXUnitTestMethods() : base("xUnitTest", "Xunit.FactAttribute")
+        private const string xUnitStrategyName = "xUnitTest";
+
+        private static readonly IList<string> TrackedAttributeTypeNames = new List<string>
+        {
+            "Xunit.FactAttribute",
+            "Xunit.TheoryAttribute",
+        };
+
+        public TrackXUnitTestMethods() : base(xUnitStrategyName, TrackedAttributeTypeNames)
         {                
         }
     }

--- a/main/OpenCover.Test/Extensions/Strategy/TrackNUnitTestMethodsTests.cs
+++ b/main/OpenCover.Test/Extensions/Strategy/TrackNUnitTestMethodsTests.cs
@@ -54,6 +54,17 @@ namespace OpenCover.Test.Extensions.Strategy
             Assert.True(methods.Any(x => x.FullName.EndsWith("SimpleNUnit::TheoryTest(System.Double)")));
         }
 
+        [Test]
+        public void TestCaseSourceAttribute_Is_Recognized()
+        {
+          // arrange            
+
+          // act
+          var methods = strategy.GetTrackedMethods(assemblyDefinition.MainModule.Types);
+
+          // assert
+          Assert.True(methods.Any(x => x.FullName.EndsWith("SimpleNUnit::DivideTest(System.Int32,System.Int32,System.Int32)")));
+        }
 
         [Test]
         public void Repeat_Is_Not_Recognized()

--- a/main/OpenCover.Test/Extensions/Strategy/TrackXUnitTestMethodsTests.cs
+++ b/main/OpenCover.Test/Extensions/Strategy/TrackXUnitTestMethodsTests.cs
@@ -22,5 +22,20 @@ namespace OpenCover.Test.Extensions.Strategy
             // assert
             Assert.True(methods.Any(x => x.FullName.EndsWith("SimpleXUnit::AddAttributeExclusionFilters_Handles_Null_Elements()")));
         }
+
+        [Test]
+        public void Can_Identify_Theories()
+        {
+            // arrange
+            var strategy = new TrackXUnitTestMethods();
+
+            var def = Mono.Cecil.AssemblyDefinition.ReadAssembly(typeof(TrackXUnitTestMethodsTests).Assembly.Location);
+
+            // act
+            var methods = strategy.GetTrackedMethods(def.MainModule.Types);
+
+            // assert
+            Assert.True(methods.Any(x => x.FullName.EndsWith("SimpleXUnit::Test_Data_Is_Even(System.Int32)")));
+        }
     }
 }

--- a/main/OpenCover.Test/Samples/SimpleNUnit.cs
+++ b/main/OpenCover.Test/Samples/SimpleNUnit.cs
@@ -27,6 +27,18 @@ namespace OpenCover.Test.Samples
         {
         }
 
+        [TestCaseSource("DivideCases")]
+        public void DivideTest(int n, int d, int q)
+        {
+            Assert.AreEqual(q, n / d);
+        }
+
+        static object[] DivideCases = {
+            new object[] { 12, 3, 4 },
+            new object[] { 12, 2, 6 },
+            new object[] { 12, 4, 3 }
+        };
+    
         [Repeat(2)]        
         public void RepeatWithoutTest()
         {

--- a/main/OpenCover.Test/Samples/SimpleXUnit.cs
+++ b/main/OpenCover.Test/Samples/SimpleXUnit.cs
@@ -19,5 +19,14 @@ namespace OpenCover.Test.Samples
 
             Assert.Equal(1, filter.ExcludedAttributes.Count);
         }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void Test_Data_Is_Even(int i)
+        {
+            Assert.Equal(i % 2, 0);
+        }
     }
 }


### PR DESCRIPTION
Please provide the following information when submitting an pull request, where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

Added support for NUnit.Framework.TestCaseSourceAttribute and Xunit.TheoryAttribute with cover by test. See [issue #611](https://github.com/OpenCover/opencover/issues/661).

### Details on the issue fix or feature implementation

Added the attributes following the existing implementation, also updated the tests and tested the results manually too.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or which ever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/662)
<!-- Reviewable:end -->
