### PR TITLE
#640 skip types that are delegates as we have no source line informat…

### DIFF
--- a/main/OpenCover.Framework/CommandLineParser.cs
+++ b/main/OpenCover.Framework/CommandLineParser.cs
@@ -141,7 +141,8 @@ namespace OpenCover.Framework
             builder.AppendLine("    [-excludebyfile:<filter>[;<filter>][;<filter>]]");
             builder.AppendLine("    [-coverbytest:<filter>[;<filter>][;<filter>]]");
             builder.AppendLine("    [[\"]-excludedirs:<excludedir>[;<excludedir>][;<excludedir>][\"]]");
-            builder.AppendLine("    [-hideskipped:File|Filter|Attribute|MissingPdb|All,[File|Filter|Attribute|MissingPdb|All]]");
+            var skips = string.Join("|", Enum.GetNames(typeof(SkippedMethod)).Where(x => x != "Unknown"));
+            builder.AppendLine(string.Format("    [-hideskipped:{0}|All,[{0}|All]]", skips));
             builder.AppendLine("    [-log:[Off|Fatal|Error|Warn|Info|Debug|Verbose|All]]");
             builder.AppendLine("    [-service[:byname]]");
             builder.AppendLine("    [-servicestarttimeout:<minutes+seconds e.g. 1m23s>");
@@ -354,11 +355,7 @@ namespace OpenCover.Framework
                 switch (option.ToLowerInvariant())
                 {
                     case "all":
-                        list.Add(SkippedMethod.Attribute);
-                        list.Add(SkippedMethod.File);
-                        list.Add(SkippedMethod.Filter);
-                        list.Add(SkippedMethod.MissingPdb);
-                        list.Add(SkippedMethod.AutoImplementedProperty);
+                        list = Enum.GetValues(typeof(SkippedMethod)).Cast<SkippedMethod>().Where(x => x != SkippedMethod.Unknown).ToList();
                         break;
                     default:
                         SkippedMethod result;

--- a/main/OpenCover.Framework/Model/SkippedMethod.cs
+++ b/main/OpenCover.Framework/Model/SkippedMethod.cs
@@ -48,6 +48,11 @@ namespace OpenCover.Framework.Model
         /// <summary>
         /// Entity (dll) was skipped due to folder exclusion.
         /// </summary>
-        FolderExclusion = 9
+        FolderExclusion = 9,
+
+        /// <summary>
+        /// Entity (method) was skipped due to being a delegate.
+        /// </summary>
+        Delegate = 10
     }
 }

--- a/main/OpenCover.Framework/Symbols/CecilSymbolManager.cs
+++ b/main/OpenCover.Framework/Symbols/CecilSymbolManager.cs
@@ -188,6 +188,11 @@ namespace OpenCover.Framework.Symbols
                 @class.MarkAsSkipped(SkippedMethod.Attribute);
             }
 
+            if (new[] {"System.MulticastDelegate", "System.Delegate"}.Contains(typeDefinition.BaseType?.FullName))
+            {
+                @class.MarkAsSkipped(SkippedMethod.Delegate);
+            }
+
             var list = new List<string>();
             if (!@class.ShouldSerializeSkippedDueTo())
             {
@@ -208,8 +213,11 @@ namespace OpenCover.Framework.Symbols
         public Method[] GetMethodsForType(Class type, File[] files)
         {
             var methods = new List<Method>();
-            IEnumerable<TypeDefinition> typeDefinitions = SourceAssembly.MainModule.Types;
-            GetMethodsForType(typeDefinitions, type.FullName, methods, files, _filter, _commandLine);
+            if (!type.ShouldSerializeSkippedDueTo())
+            {
+                IEnumerable<TypeDefinition> typeDefinitions = SourceAssembly.MainModule.Types;
+                GetMethodsForType(typeDefinitions, type.FullName, methods, files, _filter, _commandLine);
+            }
             return methods.ToArray();
         }
 

--- a/main/OpenCover.Test/Framework/CommandLineParserTests.cs
+++ b/main/OpenCover.Test/Framework/CommandLineParserTests.cs
@@ -588,7 +588,7 @@ namespace OpenCover.Test.Framework
             parser.ExtractAndValidateArguments();
 
             // assert
-            Assert.AreEqual(5, parser.HideSkipped.Distinct().Count());
+            Assert.AreEqual(Enum.GetNames(typeof(SkippedMethod)).Length - 1, parser.HideSkipped.Distinct().Count());
         }
 
         [Test]
@@ -600,7 +600,7 @@ namespace OpenCover.Test.Framework
             parser.ExtractAndValidateArguments();
 
             // assert
-            Assert.AreEqual(5, parser.HideSkipped.Distinct().Count());
+            Assert.AreEqual(Enum.GetNames(typeof(SkippedMethod)).Length - 1, parser.HideSkipped.Distinct().Count());
         }
 
         [Test]
@@ -624,7 +624,7 @@ namespace OpenCover.Test.Framework
             parser.ExtractAndValidateArguments();
 
             // assert
-            Assert.AreEqual(5, parser.HideSkipped.Distinct().Count());
+            Assert.AreEqual(Enum.GetNames(typeof(SkippedMethod)).Length - 1, parser.HideSkipped.Distinct().Count());
         }
 
         [Test]

--- a/main/OpenCover.Test/Framework/Symbols/CecilSymbolManagerTests.cs
+++ b/main/OpenCover.Test/Framework/Symbols/CecilSymbolManagerTests.cs
@@ -814,5 +814,24 @@ namespace OpenCover.Test.Framework.Symbols
             Assert.AreEqual(0, points.Count());
 
         }
+
+        [Test]
+        [TestCase("/HandleMeDelegate")]
+        [TestCase(".DontHandleMeDelegate")]
+        public void DelegatesAreSkippedAndDoNotExposeMethods(string delegateName)
+        {
+            // arrange
+            _mockFilter
+                .Setup(x => x.InstrumentClass(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(true);
+
+            var types = _reader.GetInstrumentableTypes();
+
+            var type = types.First(x => x.FullName.EndsWith(delegateName));
+            Assert.NotNull(type);
+            Assert.AreEqual(SkippedMethod.Delegate, type.SkippedDueTo);
+            var methods = _reader.GetMethodsForType(type, new File[0]);
+            Assert.AreEqual(0, methods.Length);
+        }
     }
 }

--- a/main/OpenCover.Test/Samples/Samples.cs
+++ b/main/OpenCover.Test/Samples/Samples.cs
@@ -309,4 +309,17 @@ namespace OpenCover.Test.Samples
             yield return "two";
         } 
     }
+
+
+    public class ClassWithDelegate
+    {
+        public delegate bool HandleMeDelegate();
+
+        public void CallMe(HandleMeDelegate handle)
+        {
+            
+        }
+    }
+
+    internal delegate bool DontHandleMeDelegate();
 }


### PR DESCRIPTION
…ion for them

Please provide the following information when submitting an pull request, where appropriate replace the `[ ]` with a `[X]`

#640

### Details on the issue fix or feature implementation

Skipping types that are delegates as the PDB contains no file information for them

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or which ever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/685)
<!-- Reviewable:end -->
