### PR TITLE
Integrate with the Test Adapter for Google Test

### DIFF
--- a/main/OpenCover.Test.Profiler/OpenCover.Test.Profiler.vcxproj
+++ b/main/OpenCover.Test.Profiler/OpenCover.Test.Profiler.vcxproj
@@ -108,10 +108,13 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
+    <PostBuildEvent>
+      <Command>type nul &gt;&gt; $(TargetPath).is_google_test</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -124,10 +127,13 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
+    <PostBuildEvent>
+      <Command>type nul &gt;&gt; $(TargetPath).is_google_test</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>


### PR DESCRIPTION
 -- enable discovery with DEBUG:FULL
 -- provide the magic .is_google_test hint file

### The issue or feature being addressed

#746

### Details on the issue fix or feature implementation

Switching the debug builds of the Profiler .dll and the Profiler test .exe to /DEBUG:FULL, and adding a post-build action to "touch" an empty test-indicator file

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 

---

With this change I can actually debug through unit tests in Visual Studio.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/747)
<!-- Reviewable:end -->
