### PR TITLE
Address duplicate issues #731, #771 "DirectoryNotFoundException" when .pdb points to a source file that doesn't exist

### DIFF
--- a/main/OpenCover.Framework/Utility/CodeCoverageStringTextSource.cs
+++ b/main/OpenCover.Framework/Utility/CodeCoverageStringTextSource.cs
@@ -259,16 +259,28 @@ namespace OpenCover.Framework.Utility
         public static CodeCoverageStringTextSource GetSource(string filePath) {
 
             var retSource = new CodeCoverageStringTextSource (null, filePath); // null indicates source-file not found
-            try {
-                using (Stream stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-                using (var reader = new StreamReader (stream, Encoding.Default, true)) {
-                    stream.Position = 0;
-                    retSource = new CodeCoverageStringTextSource(reader.ReadToEnd(), filePath);
+            if (System.IO.File.Exists(filePath))
+            {
+                try
+                {
+                    using (Stream stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+                    using (var reader = new StreamReader(stream, Encoding.Default, true))
+                    {
+                        stream.Position = 0;
+                        retSource = new CodeCoverageStringTextSource(reader.ReadToEnd(), filePath);
+                    }
                 }
-            } catch (Exception e) { 
-                // Source is optional (for excess-branch removal), application can continue without it
-                e.InformUser(); // Do not throw ExitApplicationWithoutReportingException
+                catch (Exception e)
+                {
+                    // Source is optional (for excess-branch removal), application can continue without it
+                    e.InformUser(); // Do not throw ExitApplicationWithoutReportingException
+                }
             }
+            else
+            {
+                String.Format("Source file {0} not found", filePath).InformUserSoft();
+            }
+
             return retSource;
         }
 

--- a/main/OpenCover.Framework/Utility/LogHelper.cs
+++ b/main/OpenCover.Framework/Utility/LogHelper.cs
@@ -34,5 +34,14 @@ namespace OpenCover.Framework.Utility
         {
             LogManager.GetLogger(loggerName).InfoFormat (message);
         }
+
+        /// <summary>
+        /// Use to inform user
+        /// </summary>
+        /// <param name="message"></param>
+        public static void InformUserSoft(this string message)
+        {
+            LogManager.GetLogger(loggerName).DebugFormat(message);
+        }
     }
 }


### PR DESCRIPTION
### The issue or feature being addressed

#731, #771

### Details on the issue fix or feature implementation

Based on [a comment on the former issue report](https://github.com/OpenCover/opencover/issues/731#issuecomment-323549650), make the message appear only at more verbose than default levels of logging.

Also, check the file exists rather than wait for an exception to happen when it doesn't

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/775)
<!-- Reviewable:end -->
