### PR TITLE
Attempt.searchdirs

### DIFF
--- a/main/OpenCover.Framework/Symbols/SymbolFileHelper.cs
+++ b/main/OpenCover.Framework/Symbols/SymbolFileHelper.cs
@@ -11,17 +11,20 @@ namespace OpenCover.Framework.Symbols
     internal static class SymbolFileHelper
     {
         /// <summary>
-        /// Locate symbol files (pbd/mdb) that are noto in the same folder as the assembly
+        /// Locate symbol files (pbd/mdb) that are not in the same folder as the assembly
         /// NOTE: due to test frameworks copying just assemblies and not the symbol files 
         /// </summary>
-        /// <param name="modulePath"></param>
-        /// <param name="commandLine"></param>
-        /// <returns></returns>
-        public static SymbolFile FindSymbolFolder(string modulePath, ICommandLine commandLine)
+        /// <param name="modulePath">Path to the module to find symbols</param>
+        /// <param name="commandLine">Command line parameters</param>
+        /// <param name="skipOriginalFolder">Optional parameter that can be used to skip the original location of the module</param>
+        /// <returns>The the first SymbolFile with matching name (not validated yet, so it can be a mismatch) or null if none is found</returns>
+        public static SymbolFile FindSymbolFolder(string modulePath, ICommandLine commandLine, bool skipOriginalFolder = false)
         {
-            var origFolder = Path.GetDirectoryName(modulePath);
+            var searchFolders = new List<string>();
+            if (!skipOriginalFolder)
+                searchFolders.Add(Path.GetDirectoryName(modulePath));
 
-            var searchFolders = new List<string> {origFolder, commandLine.TargetDir};
+            searchFolders.Add(commandLine.TargetDir);
             if (commandLine.SearchDirs != null)
                 searchFolders.AddRange(commandLine.SearchDirs);
             searchFolders.Add(Environment.CurrentDirectory);

--- a/main/OpenCover.Framework/packages.config
+++ b/main/OpenCover.Framework/packages.config
@@ -3,5 +3,5 @@
   <package id="Autofac" version="3.5.2" targetFramework="net4" />
   <package id="Autofac.Configuration" version="3.3.0" targetFramework="net4" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
-  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net452" />
+  <package id="Mono.Cecil" version="0.10.0" targetFramework="net452" />
 </packages>

--- a/main/OpenCover.Framework/packages.config
+++ b/main/OpenCover.Framework/packages.config
@@ -3,5 +3,5 @@
   <package id="Autofac" version="3.5.2" targetFramework="net4" />
   <package id="Autofac.Configuration" version="3.3.0" targetFramework="net4" />
   <package id="log4net" version="2.0.8" targetFramework="net452" />
-  <package id="Mono.Cecil" version="0.10.0" targetFramework="net452" />
+  <package id="Mono.Cecil" version="0.10.0-beta6" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Please provide the following information when submitting an pull request. 

> Where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

OpenCover bails out if the PDB on the same folder as the assembly is a mismatch. See #825 - this issue requires some hacking to get coverage for System.Private.CoreLib in CoreFx (see https://github.com/dotnet/buildtools/pull/2066)

### Details on the issue fix or feature implementation

The fix is not complete in the sense that it will fail on the first searchdir that is found but it is a mismatch, but at least looks at searchdirs in case of a mismatch.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [ ] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 

Unfortunately I was not able to get a full clean build: many warnings and some issues with tool versioning. However, I was able to build and test OpenCover.Console as it is used in dotnet/corefx repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/826)
<!-- Reviewable:end -->
