### PR TITLE
Clear compiler warning noise due to std::tr1 being deprecated

### DIFF
--- a/main/OpenCover.Test.Profiler/stdafx.h
+++ b/main/OpenCover.Test.Profiler/stdafx.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#define _SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING  1
+
 #include "targetver.h"
 
 #define _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
Please provide the following information when submitting an pull request. 

> Where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

std::tr1 has been deprecated in recent builds of VS - used by gtest/gmock 1.7.0

### Details on the issue fix or feature implementation

suppress the messages regarding the deprecation 
- also raised a card on upgrading gtest/gmock to a later version

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 
- [X] I have tagged my commits using the issue number syntax #nnn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/866)
<!-- Reviewable:end -->
