### PR TITLE
Removing duplicate modules (by hash) if -mergebyhash is set

### DIFF
--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -172,7 +172,9 @@ namespace OpenCover.Framework.Persistance
 
         private void RemoveDuplicateModulesByHash()
         {
-            CoverageSession.Modules = CoverageSession.Modules.GroupBy(x => x.ModuleHash).Select(x => x.FirstOrDefault()).ToArray();
+            CoverageSession.Modules = CoverageSession.Modules
+                .GroupBy(x => x.ModuleHash)
+                .Select(x => x.FirstOrDefault()).ToArray();
         }
 
         private void ProcessSkippedAction(SkippedMethod skippedMethod)

--- a/main/OpenCover.Framework/Persistance/BasePersistance.cs
+++ b/main/OpenCover.Framework/Persistance/BasePersistance.cs
@@ -159,6 +159,8 @@ namespace OpenCover.Framework.Persistance
         {
             if (CoverageSession.Modules == null) 
                 return;
+            if (CommandLine.MergeByHash)
+                RemoveDuplicateModulesByHash();
             MarkSkippedMethods();
             TransformSequences();
             CalculateCoverage();
@@ -166,6 +168,11 @@ namespace OpenCover.Framework.Persistance
                 return;
             foreach (var skippedMethod in CommandLine.HideSkipped.OrderBy(x => x))
                 ProcessSkippedAction(skippedMethod);
+        }
+
+        private void RemoveDuplicateModulesByHash()
+        {
+            CoverageSession.Modules = CoverageSession.Modules.GroupBy(x => x.ModuleHash).Select(x => x.FirstOrDefault()).ToArray();
         }
 
         private void ProcessSkippedAction(SkippedMethod skippedMethod)


### PR DESCRIPTION
### The issue or feature being addressed

Attempts to fix the issue reported in #908 (Intermittent duplicate Modules in XML report)

### Details on the issue fix or feature implementation

This fix is more a band-aid on the symptom, rather than a fix for the root cause. I've tried to track down why I sometimes end up with duplicate modules even with `-mergebyhash` set, but haven't been able to.

This will remove any duplicate (by hash) modules, if `-mergebyhash` is set, before scores etc. are calculated.

I'm open to suggestions on how to better fix/suppress my issue.

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [x] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 
- [X] I have tagged my commits using the issue number syntax #nnn 

I'm having issues getting the .NET Core 2.0 projects building, hoping that AppVeyor will prove the `build create-release` step for me. Otherwise just ignore the PR until I've managed to get a full local build done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/909)
<!-- Reviewable:end -->
