### PR TITLE
Add new profiler environment variables

### DIFF
--- a/main/OpenCover.Framework/Manager/ProfilerManager.cs
+++ b/main/OpenCover.Framework/Manager/ProfilerManager.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // OpenCover - S Wilde
 //
 // This source code is released under the MIT License; see the accompanying license file.
@@ -20,8 +20,8 @@ using OpenCover.Framework.Utility;
 namespace OpenCover.Framework.Manager
 {
     /// <summary>
-    /// This is the core manager for integrating the host the target 
-    /// application and the profiler 
+    /// This is the core manager for integrating the host the target
+    /// application and the profiler
     /// </summary>
     /// <remarks>It probably does too much!</remarks>
     public class ProfilerManager : IProfilerManager
@@ -173,6 +173,13 @@ namespace OpenCover.Framework.Manager
                 dictionary["Cor_Profiler_Path"] = profilerPath;
                 dictionary["CorClr_Profiler_Path"] = profilerPath;
             }
+
+            // new versions of clr and coreclr don't need us to "guess" the profiler bitness : we might as well include these
+            dictionary["Cor_Profiler_Path_32"] = ProfilerRegistration.GetProfilerPath(Registration.Path32);
+            dictionary["Cor_Profiler_Path_64"] = ProfilerRegistration.GetProfilerPath(Registration.Path64);
+            dictionary["CoreClr_Profiler_Path_32"] = ProfilerRegistration.GetProfilerPath(Registration.Path32);
+            dictionary["CoreClr_Profiler_Path_64"] = ProfilerRegistration.GetProfilerPath(Registration.Path64);
+
             dictionary["OpenCover_SendVisitPointsTimerInterval"] = _commandLine.SendVisitPointsTimerInterval.ToString();
         }
 
@@ -336,9 +343,9 @@ namespace OpenCover.Framework.Manager
                         break;
                     case 1:
                         var data = _communicationManager.HandleMemoryBlock(block.MemoryBlock);
-                        // don't let the queue get too big as using too much memory causes 
-                        // problems i.e. the target process closes down but the host takes 
-                        // ages to shutdown; this is a compromise. 
+                        // don't let the queue get too big as using too much memory causes
+                        // problems i.e. the target process closes down but the host takes
+                        // ages to shutdown; this is a compromise.
                         _messageQueue.Enqueue(data);
                         if (_messageQueue.Count > 400)
                         {


### PR DESCRIPTION
New versions of the CLR (both in the full framework and in core)
understand new environment variables specifying the profiler dll to use.

It can't hurt to set them, and as a result the profiling will work on
these platforms without needing any initial registration, nor a
-register:[whatever] option.

There are probably some issues around missing coverage that could be solved by this, but for sure it fixes #916

- [ X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [ ] I have run `build create-release` locally and have encountered no issues
- [X ] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 
- [ ] I have tagged my commits using the issue number syntax #nnn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/934)
<!-- Reviewable:end -->
