### PR TITLE
#875 trim sha used in assembly number

### DIFF
--- a/default.build
+++ b/default.build
@@ -18,7 +18,7 @@
   <property name="ci.buildNumber" value="0" unless="${property::exists('ci.buildNumber')}" />
   <property name="ci.fullBuildNumber" value="${environment::get-variable('APPVEYOR_BUILD_VERSION')}" if="${environment::variable-exists('APPVEYOR_BUILD_VERSION')}"/>
   <property name="ci.fullBuildNumber" value="0" unless="${property::exists('ci.fullBuildNumber')}" />
-  <property name="ci.gitSha" value="${environment::get-variable('APPVEYOR_REPO_COMMIT')}" if="${environment::variable-exists('APPVEYOR_REPO_COMMIT')}"/>
+  <property name="ci.gitSha" value="${string::substring(environment::get-variable('APPVEYOR_REPO_COMMIT'), 0, 7)}" if="${environment::variable-exists('APPVEYOR_REPO_COMMIT')}"/>
   <property name="ci.gitSha" value="0000000" unless="${property::exists('ci.gitSha')}" />
   <property name="coverity.folder" value="C:\Projects\cov-analysis-win64-7.7.0.4\cov-analysis-win64-7.7.0.4\bin" if="${directory::exists('C:\Projects\cov-analysis-win64-7.7.0.4\cov-analysis-win64-7.7.0.4\bin')}" />
   


### PR DESCRIPTION
Please provide the following information when submitting an pull request. 

> Where appropriate replace the `[ ]` with a `[X]`

#875 large commit sha looks ugly in Sentry 

Fill me in... 
- link to the issue/feature using its number #nnn (if an issue/feature does not exist them please create one first)

trim commit sha produced/provided by git/appveyor to 7 chars
 
Fill me in...

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 
- [X] I have tagged my commits using the issue number syntax #nnn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/984)
<!-- Reviewable:end -->
