### PR TITLE
use correct formatting syntax to handle 32 and 64 bit compilation

### DIFF
--- a/main/OpenCover.Profiler/CodeCoverage.cpp
+++ b/main/OpenCover.Profiler/CodeCoverage.cpp
@@ -330,7 +330,7 @@ HRESULT STDMETHODCALLTYPE CCodeCoverage::JITCompilationStarted(
 
         if (m_allowModules[modulePath])
         {
-            RELTRACE(_T("::JITCompilationStarted(%X, ...) => %d, %X => %s"), functionId, functionToken, moduleId, W2CT(modulePath.c_str()));
+            RELTRACE(_T("::JITCompilationStarted(%" PRIxPTR ", ...) => %d, %" PRIxPTR " => %s"), functionId, functionToken, moduleId, W2CT(modulePath.c_str()));
 
             std::vector<SequencePoint> seqPoints;
             std::vector<BranchPoint> brPoints;

--- a/main/OpenCover.Profiler/Method.cpp
+++ b/main/OpenCover.Profiler/Method.cpp
@@ -126,7 +126,7 @@ namespace Instrumentation
 		if (m_exceptions.size() > 0)
 		{
 			Align<DWORD>();
-			IMAGE_COR_ILMETHOD_SECT_FAT section;
+			IMAGE_COR_ILMETHOD_SECT_FAT section{};
 			section.Kind = CorILMethod_Sect_FatFormat;
 			section.Kind |= CorILMethod_Sect_EHTable;
 			section.DataSize = (m_exceptions.size() * 24) + 4;
@@ -284,7 +284,7 @@ namespace Instrumentation
 	{
 		if ((m_header.Flags & CorILMethod_MoreSects) == CorILMethod_MoreSects)
 		{
-			BYTE flags;
+			BYTE flags = 0;
 			do
 			{
 				Align<DWORD>(); // must be DWORD aligned
@@ -438,22 +438,22 @@ namespace Instrumentation
 			}
 			else if (details.operandSize == Byte)
 			{
-				RELTRACE(_T("(IL_%04X) IL_%04X %s %02X"),
+				RELTRACE(_T("(IL_%04X) IL_%04X %s %02" PRIxPTR),
 					(*it)->m_origOffset, (*it)->m_offset, details.stringName, (*it)->m_operand);
 			}
 			else if (details.operandSize == Word)
 			{
-				RELTRACE(_T("(IL_%04X) IL_%04X %s %04X"),
+				RELTRACE(_T("(IL_%04X) IL_%04X %s %04" PRIxPTR),
 					(*it)->m_origOffset, (*it)->m_offset, details.stringName, (*it)->m_operand);
 			}
 			else if (details.operandSize == Dword)
 			{
-				RELTRACE(_T("(IL_%04X) IL_%04X %s %08X"),
+				RELTRACE(_T("(IL_%04X) IL_%04X %s %08" PRIxPTR),
 					(*it)->m_origOffset, (*it)->m_offset, details.stringName, (*it)->m_operand);
 			}
 			else
 			{
-				RELTRACE(_T("(IL_%04X) IL_%04X %s %X"),
+				RELTRACE(_T("(IL_%04X) IL_%04X %s %" PRIxPTR),
 					(*it)->m_origOffset, (*it)->m_offset, details.stringName, (*it)->m_operand);
 			}
 			

--- a/main/OpenCover.Profiler/stdafx.h
+++ b/main/OpenCover.Profiler/stdafx.h
@@ -44,3 +44,4 @@
 #endif
 
 #include "ReleaseTrace.h"
+#include <inttypes.h>

--- a/main/OpenCover.Test.Profiler/stdafx.h
+++ b/main/OpenCover.Test.Profiler/stdafx.h
@@ -56,6 +56,8 @@
 // when it's fused.
 #include <gtest/gtest.h>
 
+#include <inttypes.h>
+
 /*
 #define _TEST_METHOD_EX_EXPANDER(_testMethod)\
 _testMethod { try


### PR DESCRIPTION
Please provide the following information when submitting an pull request. 

> Where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

codeql raised issues 

### Details on the issue fix or feature implementation

incorrect formatting when dealing with 32 and 64 bit variations of UINT_PTR

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 
- [X] I have tagged my commits using the issue number syntax #nnn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/996)
<!-- Reviewable:end -->
