### PR TITLE
add dependancy to dotnet 4.7.2 to chocolatey packages

### DIFF
--- a/ReleaseNotes.tmp
+++ b/ReleaseNotes.tmp
@@ -1,7 +1,11 @@
 Requires .NET Framework 4.7.2
 
 Version [[version]]
-#1027 option to ignore ctrl+c key press, when ctrl+c is being used to close the target process
+#1029 address issues with chocolatey packages (prj-mgmt)
+#1038 update required .net version for appveyor build (prj-mgmt)
+
+Version 4.7.1204
+#1027 option to ignore ctrl+c key press, when ctrl+c is being used to close the target process (feature)
 
 Version 4.7.1189
 #877 remove incorrect redirects (bug)

--- a/main/Opencover.Packages/chocolatey/opencover.install/opencover.install.nuspec
+++ b/main/Opencover.Packages/chocolatey/opencover.install/opencover.install.nuspec
@@ -18,6 +18,9 @@
     <summary>An open source code coverage tool (branch and sequence point) for all .NET Frameworks 2 and above. Also capable of handling 32 and 64 bit processes.</summary>
     <language>en-US</language>
     <tags>Code-Coverage Reporting Testing TDD Utility admin</tags>
+    <dependencies>
+      <dependency id="dotnet4.7.2" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\chocolateyInstall.ps1" target="tools" />

--- a/main/Opencover.Packages/chocolatey/opencover/OpenCover.nuspec
+++ b/main/Opencover.Packages/chocolatey/opencover/OpenCover.nuspec
@@ -20,6 +20,7 @@
     <tags>Code-Coverage Reporting Testing TDD Utility admin</tags>
     <dependencies>
       <dependency id="opencover.install" />
+      <dependency id="dotnet4.7.2" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Please provide the following information when submitting an pull request. 

> Where appropriate replace the `[ ]` with a `[X]`

### The issue or feature being addressed

#1029 chocolatey build not runs the installer and because the installer has a check to dot 4.7.2 this now fails 

### Details on the issue fix or feature implementation

add dependencies to to dotnet 4.7.2 in the nuspec definitions

### Confirm the following

- [X] I have ensured that I have merged the latest changes from the main branch (or whichever branch is appropriate) from opencover/opencover
- [X] I have run `build create-release` locally and have encountered no issues
- [X] I agree to follow up on any work required to resolve any issues identified whilst my request is being accepted 
- [X] I have tagged my commits using the issue number syntax #nnn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opencover/opencover/1040)
<!-- Reviewable:end -->
